### PR TITLE
Add ability to combine CHANGELOG sections across release components

### DIFF
--- a/pkg/changelog/combined.go
+++ b/pkg/changelog/combined.go
@@ -1,0 +1,61 @@
+package changelog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type CombinedChangelog map[string][]string
+
+func (c CombinedChangelog) String() string {
+	res := ""
+
+	for section, sectionValues := range c {
+		if section == "_" {
+			continue
+		}
+
+		res = res + fmt.Sprintf("### %s\n", section)
+		for _, sectionValue := range sectionValues {
+			res = res + fmt.Sprintf("- %s\n", sectionValue)
+		}
+
+		res = res + "\n"
+	}
+
+	return res
+}
+
+func NewCombinedChangelog(changelogs ...*VersionChangelog) CombinedChangelog  {
+	res := CombinedChangelog{}
+
+	sort.Slice(changelogs, func(i, j int) bool {
+		return changelogs[i].Repo < changelogs[j].Repo
+	})
+
+	for _, changelog := range changelogs {
+		for section, sectionValues := range changelog.Sections {
+			// normalise section keys
+			section = strings.ToUpper(section)
+
+			if _, ok := res[section]; !ok {
+				res[section] = []string{}
+			}
+
+			for _, value := range sectionValues {
+				res[section] = append(
+					res[section],
+					fmt.Sprintf(
+						"`%s@%s`: %s",
+						changelog.Repo,
+						changelog.Version,
+						value,
+					),
+				)
+			}
+		}
+	}
+
+	return res
+}

--- a/repositories.yml
+++ b/repositories.yml
@@ -14,6 +14,10 @@ section:
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
         version: v1.3.7
+      - name: cyberark/secretless-broker
+        url: https://github.com/cyberark/secretless-broker
+        description: Secretless Broker is a connection broker which relieves client applications of the need to directly handle secrets to target services such as databases, web services, SSH connections, or any other TCP-based service.
+        version: v1.4.2
 #      - name: cyberark/conjur-aws
 #        url: https://github.com/cyberark/conjur-aws
 #        description: AWS CloudFormation templates for deploying Conjur OSS.


### PR DESCRIPTION
This makes it possible to create a release CHANGE in the desired format, https://github.com/cyberark/conjur-oss-suite-release/issues/2#issuecomment-582567290.

Currently output from running `./parse-changelogs`
```
### Added
- `cyberark/conjur-api-java@2.0.0`: License updated to Apache v2 - PR [8](https://github.com/cyberark/conjur-api-java/pull/8)
- `cyberark/conjur-api-python3@0.0.5`: Added ability to delete policies [#23](https://github.com/cyberark/conjur-api-python3/issues/23)
- `cyberark/secretless-broker@1.4.2`: Updated CONTRIBUTING.md with instructions for using `go-mssqldb` submodule (#1044)
- `cyberark/secretless-broker@1.4.2`: Added gosec security scan to pipeline (#976)
- `cyberark/secretless-broker@1.4.2`: Added integration tests for MSSQL against additional MSSQL versions (#1017)
- `cyberark/secretless-broker@1.4.2`: Added `gofmt` to CodeClimate checks (#1055)
- `cyberark/secretless-broker@1.4.2`: Added support for MSSQL client parameter propagation (#1012)

### Fixed
- `cyberark/secretless-broker@1.4.2`: Secretless doesn't exit when it can't start a configured connector (#1057)
- `cyberark/secretless-broker@1.4.2`: Secretless has insufficient logs when the config file has trouble loading (#1062)

### Changed
- `cyberark/conjur@1.4.6`: K8s hosts' application identity is extracted from annotations or id. If it is
- `cyberark/conjur-api-java@2.0.0`: Authn tokens now use the new Conjur 5 format - PR [21](https://github.com/cyberark/conjur-api-java/pull/21)
- `cyberark/conjur-api-java@2.0.0`: Configuration change. When using environment variables, use `CONJUR_AUTHN_LOGIN` and `CONJUR_AUTHN_API_KEY` now
- `cyberark/conjur-oss-helm-chart@1.3.7`: Server ciphers have been upgraded to TLS1.2 levels.
- `cyberark/secretless-broker@1.4.2`: Bumped the `conjur-authn-k8s-client` version for the Conjur provider k8s
- `cyberark/secretless-broker@1.4.2`: Example plugin updated for clarity (#1061)
- `cyberark/secretless-broker@1.4.2`: Plugin SDK templates updated for clarity (#1054)
- `cyberark/secretless-broker@1.4.2`: Removed hardcoded PreloginResponse from MSSQL connector (#1014)
- `cyberark/secretless-broker@1.4.2`: Bumped Go version in Dockerfile to 1.13
```