### PR TITLE
Added semantic version filtering module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cyberark/conjur-oss-suite-release
 go 1.13
 
 require (
+	github.com/coreos/go-semver v0.3.0
 	github.com/gomarkdown/markdown v0.0.0-20200127000047-1813ea067497
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
+github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gomarkdown/markdown v0.0.0-20200127000047-1813ea067497 h1:wJkj+x9gPYlDyM34C6r3SXPs270coWeh85wu1CsusDo=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,77 @@
+package version
+
+import (
+	"github.com/coreos/go-semver/semver"
+)
+
+func versionFromString(versionStr string) (*semver.Version, error) {
+	// Strip the 'v' from the beginning, if present
+	if versionStr[0] == 'v' {
+		versionStr = versionStr[1:]
+	}
+
+	return semver.NewVersion(versionStr)
+}
+
+// GetRelevantVersions sorts and returns the list of versions from highest
+// (included) to the lowest (excluded). The method auto-detects what's the
+// lower and what's the higher range bound.
+func GetRelevantVersions(availVersionsStr []string,
+	startVersionStr string,
+	endVersionStr string) ([]string, error) {
+
+	// Parse the higher limit version from the provided string
+	highVersion, err := versionFromString(endVersionStr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the lower limit version from the provided string
+	lowVersion, err := versionFromString(startVersionStr)
+	if err != nil {
+		return nil, err
+	}
+
+	// If low and high limits are swapped, fix them
+	if highVersion.LessThan(*lowVersion) {
+		highVersion, lowVersion = lowVersion, highVersion
+	}
+
+	// Special case: same semver as both high and low should just
+	// return the single version for fetching
+	if highVersion.Equal(*lowVersion) {
+		return []string{"v" + highVersion.String()}, nil
+	}
+
+	versions := []*semver.Version{}
+	for _, versionStr := range availVersionsStr {
+		// Parse the version from the provided string
+		version, err := versionFromString(versionStr)
+		if err != nil {
+			return nil, err
+		}
+
+		// Skip versions higher than highest indicated version.
+		if highVersion.LessThan(*version) {
+			continue
+		}
+
+		// Skip versions lower-or-equal than lowest indicated version.
+		if version.LessThan(*lowVersion) || version.Equal(*lowVersion) {
+			continue
+		}
+
+		versions = append(versions, version)
+	}
+
+	// Sort the output since we need to pull data in that order
+	semver.Sort(versions)
+
+	// Convert back to strings our version data
+	filteredVersionNames := []string{}
+	for _, version := range versions {
+		filteredVersionNames = append(filteredVersionNames, "v"+(*version).String())
+	}
+
+	return filteredVersionNames, nil
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,97 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var versionFixtureData = []string{
+	"v1.3.4",
+	"v1.3.3",
+	"v1.20.0",
+	"v0.29.20",
+	"v0.2.0",
+	"v0.1.3",
+}
+
+func TestGetRelevantVersionsWithComplexVersions(t *testing.T) {
+	relevantVersions, err := GetRelevantVersions(versionFixtureData, "v0.1.3", "v1.3.4")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(
+		t,
+		[]string{
+			"v0.2.0",
+			"v0.29.20",
+			"v1.3.3",
+			"v1.3.4",
+		},
+		relevantVersions)
+}
+
+func TestGetRelevantVersionsWithSwappedHighAndLowVersions(t *testing.T) {
+	relevantVersions, err := GetRelevantVersions(versionFixtureData, "v1.3.4", "v0.1.3")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(
+		t,
+		[]string{
+			"v0.2.0",
+			"v0.29.20",
+			"v1.3.3",
+			"v1.3.4",
+		},
+		relevantVersions)
+}
+
+func TestGetRelevantVersionsWithSameVersion(t *testing.T) {
+	versions := []string{
+		"v1.3.4",
+		"v1.3.3",
+		"v1.20.0",
+	}
+	relevantVersions, err := GetRelevantVersions(versions, "v1.3.3", "v1.3.3")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, []string{"v1.3.3"}, relevantVersions)
+}
+
+func TestGetRelevantVersionsWithBadVersionInList(t *testing.T) {
+	versions := []string{
+		"v1.3.4",
+		"v1.3.3",
+		"1.20",
+	}
+
+	_, err := GetRelevantVersions(versions, "v1.20.0", "v1.3.3")
+	if !assert.Error(t, err) {
+		return
+	}
+
+	assert.EqualError(t, err, "1.20 is not in dotted-tri format")
+}
+
+func TestGetRelevantVersionsBadHighVersion(t *testing.T) {
+	_, err := GetRelevantVersions([]string{}, "123", "v1.3.3")
+	if !assert.Error(t, err) {
+		return
+	}
+
+	assert.EqualError(t, err, "123 is not in dotted-tri format")
+}
+
+func TestGetRelevantVersionsBadLowVersion(t *testing.T) {
+	_, err := GetRelevantVersions([]string{}, "v1.2.3", "asddsf")
+	if !assert.Error(t, err) {
+		return
+	}
+
+	assert.EqualError(t, err, "asddsf is not in dotted-tri format")
+}


### PR DESCRIPTION
While this is not currently used, it is required for us to be able to
create a sorted list of versions that we need to consider for inclusion
in the resulting artifacts.