### PR TITLE
21 Added basic per-repo release notes listing

### DIFF
--- a/templates/RELEASE_NOTES_unified.md.tmpl
+++ b/templates/RELEASE_NOTES_unified.md.tmpl
@@ -1,0 +1,13 @@
+# Release Notes
+All notable changes to this project will be documented in this file.
+
+## [{{ .Version }}] - {{ .Date.Format "2006-01-02" }}
+{{ range .Changelogs }}
+### Changes to '{{ .Repo }}@{{ .Version}}' ({{ .Date }}) since last release
+{{ range $sectionKey, $sectionValues := .Sections }}
+#### {{ $sectionKey }}
+{{- range $sectionItem := $sectionValues }}
+- {{ $sectionItem -}}
+{{ end }}
+{{ end }}
+{{- end }}


### PR DESCRIPTION
This enables us to list changes per repo as an alternate way to output
the changelog data. This will be very useful when we need to generate
release notes for the OSS suite release.