### PR TITLE
52 Add API CLI token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ and monitor the [github issues](https://github.com/cyberark/conjur-oss-suite-rel
 ```
 - Resulting changelog will be placed in `CHANGELOG.md`
 
+## Advanced usage
+
+The CLI accepts the following arguments/parameters:
+```
+  -f string
+        Repository YAML file to parse (default "repositories.yml")
+  -o string
+        Output filename (default "CHANGELOG.md")
+  -p string
+        GitHub API token
+  -t string
+        Output type. Only accepts 'changelog' and 'release'. (default "changelog")
+  -v string
+        Version to embed in the changelog (default "Unreleased")
+```
+
 ## Development
 We welcome contributions of all kinds. For instructions on how to get started and
 descriptions of our development workflows, please see our [contributing guide](CONTRIBUTING.md).

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -7,19 +7,32 @@ import (
 	stdlibHttp "net/http"
 )
 
-// Get retrieves the content of a URL
-func Get(url string) ([]byte, error) {
-	client := &stdlibHttp.Client{}
-	return GetWithOptions(url, client)
+// Client is a wrapper around stdlibHttp client but with added storage for
+// an auth token
+type Client struct {
+	*stdlibHttp.Client
+	AuthToken string
 }
 
-// GetWithOptions retrieves the content of a URL but with the
-// ability to also specify a client which is useful for mocking
-// and tests
-func GetWithOptions(url string, client *stdlibHttp.Client) ([]byte, error) {
+// NewClient creates a Client with an initialized parent stdlibHttp.Client
+// object
+func NewClient() *Client {
+	return &Client{
+		&stdlibHttp.Client{},
+		"",
+	}
+}
+
+// Get retrieves the content of a URL
+func (client *Client) Get(url string) ([]byte, error) {
 	request, err := stdlibHttp.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	// Add API auth token if one is provided
+	if client.AuthToken != "" {
+		request.Header.Add("Authorization", "token "+client.AuthToken)
 	}
 
 	log.Printf("  Fetching %s...", url)


### PR DESCRIPTION
This will make use of the tool much easier and less likely to end in info disclosure when we reach the low unauthenticated API limit.

Issue: #52 