### PR TITLE
Markdown parser renders unimplemented leaf nodes as plaintext

### DIFF
--- a/pkg/changelog/parse.go
+++ b/pkg/changelog/parse.go
@@ -179,6 +179,18 @@ func Parse(repo string, changelog string) ([]*VersionChangelog, error) {
 					sectionBuffer = ""
 				}
 			}
+		// Handle any other leaf-nodes same as text-nodes
+		default:
+			if leafNode := node.AsLeaf(); leafNode != nil {
+				switch {
+				case insideVersion:
+					versionBuffer += string(leafNode.Literal)
+				case insideSection:
+					sectionBuffer += string(leafNode.Literal)
+				case insideListItem:
+					listItemBuffer += string(leafNode.Literal)
+				}
+			}
 		}
 
 		return ast.GoToNext

--- a/pkg/changelog/parse_test.go
+++ b/pkg/changelog/parse_test.go
@@ -30,6 +30,7 @@ func TestParseSimpleChangelog(t *testing.T) {
 		Sections: map[string][]string{
 			"Added": {
 				"add 1",
+				"cyberark/conjur@1.4.4: Bumped toolset from 3.12.0 to 3.12.2",
 			},
 			"Changed": {
 				"change 1",

--- a/pkg/changelog/testdata/changelog.simple.md
+++ b/pkg/changelog/testdata/changelog.simple.md
@@ -6,6 +6,7 @@ description
 
 ### Added
 - add 1
+- `cyberark/conjur@1.4.4`: Bumped `toolset` from 3.12.0 to 3.12.2
 
 ### Changed
 - change 1


### PR DESCRIPTION
Each leaf node's textual representation must be implemented in the parser. In the meantime, any leaf node without an implementation will just be represented as plaintext