### PR TITLE
61 Add component versions to release notes

### DIFF
--- a/cmd/changelog-parser/testdata/expected_release_output.txt
+++ b/cmd/changelog-parser/testdata/expected_release_output.txt
@@ -3,7 +3,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - 2020-02-19
 
-### Changes to 'cyberark/conjur@1.3.6' (2019-02-19) since last release
+## Table of Contents
+
+- [Components](#components)
+- [Changes](#changes)
+
+## Components
+
+These are the components that combine to create this Conjur OSS Suite release and links
+to their releases:
+
+- [cyberark/conjur v1.3.6 (2019-02-19)](https://github.com/cyberark/conjur/releases/tag/v1.3.6)
+- [cyberark/conjur v1.4.4 (2019-12-19)](https://github.com/cyberark/conjur/releases/tag/v1.4.4)
+- [cyberark/conjur v1.4.6 (2020-01-21)](https://github.com/cyberark/conjur/releases/tag/v1.4.6)
+- [cyberark/conjur-api-python3 v0.0.5 (2019-12-06)](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5)
+- [cyberark/conjur-oss-helm-chart v1.3.7 (2019-01-31)](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7)
+
+## Changes
+
+The following are changes to the constituent components since the last Conjur
+OSS Suite release:
+
+### [cyberark/conjur v1.3.6](https://github.com/cyberark/conjur/releases/tag/v1.3.6) (2019-02-19)
 
 #### Changed
 - Reduced IAM authentication logging
@@ -12,7 +33,7 @@ All notable changes to this project will be documented in this file.
 #### Removed
 - Removed OIDC APIs public access
 
-### Changes to 'cyberark/conjur@1.4.4' (2019-12-19) since last release
+### [cyberark/conjur v1.4.4](https://github.com/cyberark/conjur/releases/tag/v1.4.4) (2019-12-19)
 
 #### Added
 - Early validation of account existence during OIDC authentication
@@ -31,19 +52,19 @@ All notable changes to this project will be documented in this file.
 #### Removed
 - Removed follower env configuration
 
-### Changes to 'cyberark/conjur@1.4.6' (2020-01-21) since last release
+### [cyberark/conjur v1.4.6](https://github.com/cyberark/conjur/releases/tag/v1.4.6) (2020-01-21)
 
 #### Changed
 - K8s hosts&#39; application identity is extracted from annotations or id. If it is
 defined in annotations it will taken from there and if not, it will be taken
 from the id.
 
-### Changes to 'cyberark/conjur-api-python3@0.0.5' (2019-12-06) since last release
+### [cyberark/conjur-api-python3 v0.0.5](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5) (2019-12-06)
 
 #### Added
 - Added ability to delete policies [#23](https://github.com/cyberark/conjur-api-python3/issues/23)
 
-### Changes to 'cyberark/conjur-oss-helm-chart@1.3.7' (2019-01-31) since last release
+### [cyberark/conjur-oss-helm-chart v1.3.7](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7) (2019-01-31)
 
 #### Changed
 - Server ciphers have been upgraded to TLS1.2 levels.

--- a/templates/RELEASE_NOTES_unified.md.tmpl
+++ b/templates/RELEASE_NOTES_unified.md.tmpl
@@ -21,7 +21,7 @@ to their releases:
 The following are changes to the constituent components since the last Conjur
 OSS Suite release:
 {{ range .Changelogs }}
-### Changes to '{{ .Repo }}@{{ .Version}}' ({{ .Date }}) since last release
+### [{{ .Repo }} v{{ .Version}}](https://github.com/{{ .Repo }}/releases/tag/v{{ .Version }}) ({{ .Date }})
 {{ range $sectionKey, $sectionValues := .Sections }}
 #### {{ $sectionKey }}
 {{- range $sectionItem := $sectionValues }}

--- a/templates/RELEASE_NOTES_unified.md.tmpl
+++ b/templates/RELEASE_NOTES_unified.md.tmpl
@@ -2,6 +2,24 @@
 All notable changes to this project will be documented in this file.
 
 ## [{{ .Version }}] - {{ .Date.Format "2006-01-02" }}
+
+## Table of Contents
+
+- [Components](#components)
+- [Changes](#changes)
+
+## Components
+
+These are the components that combine to create this Conjur OSS Suite release and links
+to their releases:
+{{ range .Changelogs }}
+- [{{ .Repo }} v{{ .Version}} ({{ .Date }})](https://github.com/{{ .Repo }}/releases/tag/v{{ .Version }})
+{{- end }}
+
+## Changes
+
+The following are changes to the constituent components since the last Conjur
+OSS Suite release:
 {{ range .Changelogs }}
 ### Changes to '{{ .Repo }}@{{ .Version}}' ({{ .Date }}) since last release
 {{ range $sectionKey, $sectionValues := .Sections }}

--- a/templates/testdata/RELEASE_NOTES_unified.md
+++ b/templates/testdata/RELEASE_NOTES_unified.md
@@ -3,7 +3,25 @@ All notable changes to this project will be documented in this file.
 
 ## [11.22.33] - 2020-02-19
 
-### Changes to 'cyberark/conjur@1.3.6' (2020-02-01) since last release
+## Table of Contents
+
+- [Components](#components)
+- [Changes](#changes)
+
+## Components
+
+These are the components that combine to create this Conjur OSS Suite release and links
+to their releases:
+
+- [cyberark/conjur v1.3.6 (2020-02-01)](https://github.com/cyberark/conjur/releases/tag/v1.3.6)
+- [cyberark/conjur v1.4.4 (2020-01-03)](https://github.com/cyberark/conjur/releases/tag/v1.4.4)
+
+## Changes
+
+The following are changes to the constituent components since the last Conjur
+OSS Suite release:
+
+### [cyberark/conjur v1.3.6](https://github.com/cyberark/conjur/releases/tag/v1.3.6) (2020-02-01)
 
 #### Changed
 - 136Change
@@ -12,7 +30,7 @@ All notable changes to this project will be documented in this file.
 #### Removed
 - 136Removal
 
-### Changes to 'cyberark/conjur@1.4.4' (2020-01-03) since last release
+### [cyberark/conjur v1.4.4](https://github.com/cyberark/conjur/releases/tag/v1.4.4) (2020-01-03)
 
 #### Added
 - 144Addition


### PR DESCRIPTION
This adds a ToC and component version listing to the release notes. This does not de-duplicate versions from the same repository yet though which will be handled in the follow-up work.

As part of these changes, improvements were made to the listing of the changeset brevity as well.

Issue #61 