### PR TITLE
Made release notes output only link to latest component release

### DIFF
--- a/cmd/changelog-parser/main.go
+++ b/cmd/changelog-parser/main.go
@@ -143,9 +143,9 @@ func componentFromRepo(httpClient *http.Client, repo repositories.Repository) (t
 		}
 
 		// If this changelog is for the suite release pinned version, save the release
-		// date. Since VersionChangelogs are stripped of `v` prefix, we need it back for
-		// this comparison.
-		if "v"+versionChangelog.Version == component.ReleaseName {
+		// date. Since we don't know if there will be `v` prefixes, we compare the
+		// strings without them.
+		if strings.TrimPrefix(versionChangelog.Version, "v") == strings.TrimPrefix(component.ReleaseName, "v") {
 			component.ReleaseDate = versionChangelog.Date
 		}
 

--- a/cmd/changelog-parser/main.go
+++ b/cmd/changelog-parser/main.go
@@ -79,8 +79,12 @@ func fetchChangelog(
 	return string(changelog), nil
 }
 
-func componentFromRepo(httpClient *http.Client, repo repositories.Repository) (template.Component, error) {
-	component := template.Component{
+func componentFromRepo(
+	httpClient *http.Client,
+	repo repositories.Repository,
+) (template.SuiteComponent, error) {
+
+	component := template.SuiteComponent{
 		Repo: repo.Name,
 	}
 
@@ -159,10 +163,10 @@ func componentFromRepo(httpClient *http.Client, repo repositories.Repository) (t
 }
 
 func collectComponents(repoConfig repositories.Config, httpClient *http.Client) (
-	[]template.Component,
+	[]template.SuiteComponent,
 	error,
 ) {
-	var components []template.Component
+	var components []template.SuiteComponent
 	for _, category := range repoConfig.Section.Categories {
 		log.Printf("Processing category: %s", category.Name)
 		for _, repo := range category.Repos {
@@ -233,7 +237,7 @@ func runParser(options cliOptions) {
 		options.Date = time.Now()
 	}
 
-	templateData := template.SuiteData{
+	templateData := template.ReleaseSuite{
 		// TODO: Suite version should probably be read from some file
 		Version:          options.Version,
 		Date:             options.Date,

--- a/cmd/changelog-parser/testdata/expected_release_output.txt
+++ b/cmd/changelog-parser/testdata/expected_release_output.txt
@@ -13,11 +13,9 @@ All notable changes to this project will be documented in this file.
 These are the components that combine to create this Conjur OSS Suite release and links
 to their releases:
 
-- [cyberark/conjur v1.3.6 (2019-02-19)](https://github.com/cyberark/conjur/releases/tag/v1.3.6)
-- [cyberark/conjur v1.4.4 (2019-12-19)](https://github.com/cyberark/conjur/releases/tag/v1.4.4)
 - [cyberark/conjur v1.4.6 (2020-01-21)](https://github.com/cyberark/conjur/releases/tag/v1.4.6)
-- [cyberark/conjur-api-python3 v0.0.5 (2019-12-06)](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5)
 - [cyberark/conjur-oss-helm-chart v1.3.7 (2019-01-31)](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7)
+- [cyberark/conjur-api-python3 v0.0.5 (2019-12-06)](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5)
 
 ## Changes
 
@@ -59,13 +57,13 @@ OSS Suite release:
 defined in annotations it will taken from there and if not, it will be taken
 from the id.
 
-### [cyberark/conjur-api-python3 v0.0.5](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5) (2019-12-06)
-
-#### Added
-- Added ability to delete policies [#23](https://github.com/cyberark/conjur-api-python3/issues/23)
-
 ### [cyberark/conjur-oss-helm-chart v1.3.7](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7) (2019-01-31)
 
 #### Changed
 - Server ciphers have been upgraded to TLS1.2 levels.
+
+### [cyberark/conjur-api-python3 v0.0.5](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5) (2019-12-06)
+
+#### Added
+- Added ability to delete policies [#23](https://github.com/cyberark/conjur-api-python3/issues/23)
 

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -13,7 +13,8 @@ type describedObject struct {
 	Description string
 }
 
-type repository struct {
+// Repository represents a codified description of a target component
+type Repository struct {
 	describedObject `yaml:",inline"`
 	URL             string
 	Version         string `yaml:omitempty`
@@ -22,7 +23,7 @@ type repository struct {
 
 type category struct {
 	describedObject `yaml:",inline"`
-	Repos           []repository
+	Repos           []Repository
 }
 
 type section struct {

--- a/pkg/repositories/repositories_test.go
+++ b/pkg/repositories/repositories_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newTestRepoObject(name string) repository {
-	return repository{
+func newTestRepoObject(name string) Repository {
+	return Repository{
 		describedObject: describedObject{
 			Name:        name + " Name",
 			Description: name + " Description",
@@ -27,7 +27,7 @@ func TestNewConfig(t *testing.T) {
 				Name:        "Category1",
 				Description: "Category1 Description",
 			},
-			Repos: []repository{
+			Repos: []Repository{
 				expectedRepo1,
 				newTestRepoObject("Repo2"),
 			},
@@ -37,7 +37,7 @@ func TestNewConfig(t *testing.T) {
 				Name:        "Category2",
 				Description: "Category2 Description",
 			},
-			Repos: []repository{
+			Repos: []Repository{
 				newTestRepoObject("Repo3"),
 			},
 		},

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -10,20 +10,20 @@ import (
 	"github.com/cyberark/conjur-oss-suite-release/pkg/changelog"
 )
 
-// Component represents a suite component with all of its changelogs and relevant
-// pin data
-type Component struct {
+// SuiteComponent represents a suite component with all of its changelogs and
+// relevant pin data
+type SuiteComponent struct {
 	Repo        string
 	Changelogs  []*changelog.VersionChangelog
 	ReleaseName string
 	ReleaseDate string
 }
 
-// SuiteData stores all the data needed for generation of templates in the suite
-type SuiteData struct {
+// ReleaseSuite stores all the data needed for generation of templates in the suite
+type ReleaseSuite struct {
 	Version          string
 	Date             time.Time
-	Components       []Component
+	Components       []SuiteComponent
 	UnifiedChangelog string
 }
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -10,12 +10,20 @@ import (
 	"github.com/cyberark/conjur-oss-suite-release/pkg/changelog"
 )
 
-// UnifiedChangelogTemplateData stores all the data needed for generation of
-// templates
-type UnifiedChangelogTemplateData struct {
+// Component represents a suite component with all of its changelogs and relevant
+// pin data
+type Component struct {
+	Repo        string
+	Changelogs  []*changelog.VersionChangelog
+	ReleaseName string
+	ReleaseDate string
+}
+
+// SuiteData stores all the data needed for generation of templates in the suite
+type SuiteData struct {
 	Version          string
 	Date             time.Time
-	Changelogs       []*changelog.VersionChangelog
+	Components       []Component
 	UnifiedChangelog string
 }
 

--- a/templates/RELEASE_NOTES_unified.md.tmpl
+++ b/templates/RELEASE_NOTES_unified.md.tmpl
@@ -12,14 +12,15 @@ All notable changes to this project will be documented in this file.
 
 These are the components that combine to create this Conjur OSS Suite release and links
 to their releases:
-{{ range .Changelogs }}
-- [{{ .Repo }} v{{ .Version}} ({{ .Date }})](https://github.com/{{ .Repo }}/releases/tag/v{{ .Version }})
+{{ range .Components }}
+- [{{ .Repo }} {{ .ReleaseName }} ({{ .ReleaseDate }})](https://github.com/{{ .Repo }}/releases/tag/{{ .ReleaseName }})
 {{- end }}
 
 ## Changes
 
 The following are changes to the constituent components since the last Conjur
 OSS Suite release:
+{{ range .Components -}}
 {{ range .Changelogs }}
 ### [{{ .Repo }} v{{ .Version}}](https://github.com/{{ .Repo }}/releases/tag/v{{ .Version }}) ({{ .Date }})
 {{ range $sectionKey, $sectionValues := .Sections }}
@@ -28,4 +29,5 @@ OSS Suite release:
 - {{ $sectionItem -}}
 {{ end }}
 {{ end }}
+{{- end }}
 {{- end }}

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -50,30 +50,37 @@ func TestTemplates(t *testing.T) {
 	date1, _ := time.Parse(time.RFC3339, "2020-02-01T11:58:05Z")
 	date2, _ := time.Parse(time.RFC3339, "2020-01-03T11:58:05Z")
 
-	testData := template.UnifiedChangelogTemplateData{
+	testData := template.SuiteData{
 		Version:          "11.22.33",
 		Date:             outputDate,
 		UnifiedChangelog: "@@@Unified changelog content@@@",
-		Changelogs: []*changelog.VersionChangelog{
-			&changelog.VersionChangelog{
-				Repo:    "cyberark/conjur",
-				Version: "1.3.6",
-				// Why are these strings?
-				Date: date1.Format("2006-01-02"),
-				Sections: map[string][]string{
-					"Changed": []string{"136Change", "136Change2"},
-					"Removed": []string{"136Removal"},
-				},
-			},
-			&changelog.VersionChangelog{
-				Repo:    "cyberark/conjur",
-				Version: "1.4.4",
-				// Why are these strings?
-				Date: date2.Format("2006-01-02"),
-				Sections: map[string][]string{
-					"Added":   []string{"144Addition", "144Addition2"},
-					"Changed": []string{"144Change", "144Change2"},
-					"Fixed":   []string{"144Fix"},
+		Components: []template.Component{
+			template.Component{
+				Repo:        "cyberark/conjur",
+				ReleaseName: "v1.4.4",
+				ReleaseDate: date2.Format("2006-01-02"),
+				Changelogs: []*changelog.VersionChangelog{
+					&changelog.VersionChangelog{
+						Repo:    "cyberark/conjur",
+						Version: "1.3.6",
+						// Why are these strings?
+						Date: date1.Format("2006-01-02"),
+						Sections: map[string][]string{
+							"Changed": []string{"136Change", "136Change2"},
+							"Removed": []string{"136Removal"},
+						},
+					},
+					&changelog.VersionChangelog{
+						Repo:    "cyberark/conjur",
+						Version: "1.4.4",
+						// Why are these strings?
+						Date: date2.Format("2006-01-02"),
+						Sections: map[string][]string{
+							"Added":   []string{"144Addition", "144Addition2"},
+							"Changed": []string{"144Change", "144Change2"},
+							"Fixed":   []string{"144Fix"},
+						},
+					},
 				},
 			},
 		},

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -50,12 +50,12 @@ func TestTemplates(t *testing.T) {
 	date1, _ := time.Parse(time.RFC3339, "2020-02-01T11:58:05Z")
 	date2, _ := time.Parse(time.RFC3339, "2020-01-03T11:58:05Z")
 
-	testData := template.SuiteData{
+	testData := template.ReleaseSuite{
 		Version:          "11.22.33",
 		Date:             outputDate,
 		UnifiedChangelog: "@@@Unified changelog content@@@",
-		Components: []template.Component{
-			template.Component{
+		Components: []template.SuiteComponent{
+			template.SuiteComponent{
 				Repo:        "cyberark/conjur",
 				ReleaseName: "v1.4.4",
 				ReleaseDate: date2.Format("2006-01-02"),

--- a/templates/testdata/RELEASE_NOTES_unified.md
+++ b/templates/testdata/RELEASE_NOTES_unified.md
@@ -13,7 +13,6 @@ All notable changes to this project will be documented in this file.
 These are the components that combine to create this Conjur OSS Suite release and links
 to their releases:
 
-- [cyberark/conjur v1.3.6 (2020-02-01)](https://github.com/cyberark/conjur/releases/tag/v1.3.6)
 - [cyberark/conjur v1.4.4 (2020-01-03)](https://github.com/cyberark/conjur/releases/tag/v1.4.4)
 
 ## Changes


### PR DESCRIPTION
To support this change, the layout of our data was changed so that we
have per-component hierarchy rather than per-changelog so that we can
enumerate releases as well as only show the latest one per component in
the templates.