### PR TITLE
68 Add upgrade instructions to release notes

### DIFF
--- a/cmd/changelog-parser/main.go
+++ b/cmd/changelog-parser/main.go
@@ -86,7 +86,8 @@ func componentFromRepo(
 ) (template.SuiteComponent, error) {
 
 	component := template.SuiteComponent{
-		Repo: repo.Name,
+		Repo:       repo.Name,
+		UpgradeURL: repo.UpgradeURL,
 	}
 
 	var changelogs []*changelogPkg.VersionChangelog

--- a/cmd/changelog-parser/testdata/expected_release_output.txt
+++ b/cmd/changelog-parser/testdata/expected_release_output.txt
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## Table of Contents
 
 - [Components](#components)
+- [Upgrade Instructions](#upgrade-instructions)
 - [Changes](#changes)
 
 ## Components
@@ -13,9 +14,14 @@ All notable changes to this project will be documented in this file.
 These are the components that combine to create this Conjur OSS Suite release and links
 to their releases:
 
-- [cyberark/conjur v1.4.6 (2020-01-21)](https://github.com/cyberark/conjur/releases/tag/v1.4.6)
-- [cyberark/conjur-oss-helm-chart v1.3.7 (2019-01-31)](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7)
-- [cyberark/conjur-api-python3 v0.0.5 (2019-12-06)](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5)
+- **[cyberark/conjur v1.4.6](https://github.com/cyberark/conjur/releases/tag/v1.4.6)** (2020-01-21)
+- **[cyberark/conjur-oss-helm-chart v1.3.7](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7)** (2019-01-31)
+- **[cyberark/conjur-api-python3 v0.0.5](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5)** (2019-12-06)
+
+## Upgrade Instructions
+
+Upgrade instructions are available for the following components:
+
 
 ## Changes
 

--- a/cmd/changelog-parser/testdata/expected_release_output.txt
+++ b/cmd/changelog-parser/testdata/expected_release_output.txt
@@ -22,6 +22,7 @@ to their releases:
 
 Upgrade instructions are available for the following components:
 
+- [cyberark/conjur](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm)
 
 ## Changes
 

--- a/cmd/changelog-parser/testdata/repositories.yml
+++ b/cmd/changelog-parser/testdata/repositories.yml
@@ -12,6 +12,7 @@ section:
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         version: v1.4.6
         after: v1.3.5
+        upgrade_url: https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -19,6 +19,7 @@ type Repository struct {
 	URL             string
 	Version         string `yaml:omitempty`
 	AfterVersion    string `yaml:"after",omitempty`
+	UpgradeURL      string `yaml:"upgrade_url",omitempty`
 }
 
 type category struct {

--- a/pkg/repositories/repositories_test.go
+++ b/pkg/repositories/repositories_test.go
@@ -12,14 +12,18 @@ func newTestRepoObject(name string) Repository {
 			Name:        name + " Name",
 			Description: name + " Description",
 		},
-		URL:     name + " URL",
-		Version: name + " Version",
+		URL:        name + " URL",
+		Version:    name + " Version",
+		UpgradeURL: name + " Upgrade Url",
 	}
 }
 
 func testfileExpectedConfig() Config {
 	expectedRepo1 := newTestRepoObject("Repo1")
 	expectedRepo1.AfterVersion = "Repo1 After Version"
+
+	expectedRepo2 := newTestRepoObject("Repo2")
+	expectedRepo2.UpgradeURL = ""
 
 	expectedCategories := []category{
 		category{
@@ -29,7 +33,7 @@ func testfileExpectedConfig() Config {
 			},
 			Repos: []Repository{
 				expectedRepo1,
-				newTestRepoObject("Repo2"),
+				expectedRepo2,
 			},
 		},
 		category{

--- a/pkg/repositories/testdata/repositories.yml
+++ b/pkg/repositories/testdata/repositories.yml
@@ -11,6 +11,7 @@ section:
         description: Repo1 Description
         version: Repo1 Version
         after: Repo1 After Version
+        upgrade_url: Repo1 Upgrade Url
       - name: Repo2 Name
         url: Repo2 URL
         description: Repo2 Description
@@ -22,3 +23,4 @@ section:
         url: Repo3 URL
         description: Repo3 Description
         version: Repo3 Version
+        upgrade_url: Repo3 Upgrade Url

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -17,6 +17,7 @@ type SuiteComponent struct {
 	Changelogs  []*changelog.VersionChangelog
 	ReleaseName string
 	ReleaseDate string
+	UpgradeURL  string
 }
 
 // ReleaseSuite stores all the data needed for generation of templates in the suite

--- a/repositories.yml
+++ b/repositories.yml
@@ -11,6 +11,7 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         after: v1.3.5
+        upgrade_url: https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.

--- a/templates/RELEASE_NOTES_unified.md.tmpl
+++ b/templates/RELEASE_NOTES_unified.md.tmpl
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## Table of Contents
 
 - [Components](#components)
+- [Upgrade Instructions](#upgrade-instructions)
 - [Changes](#changes)
 
 ## Components
@@ -13,7 +14,16 @@ All notable changes to this project will be documented in this file.
 These are the components that combine to create this Conjur OSS Suite release and links
 to their releases:
 {{ range .Components }}
-- [{{ .Repo }} {{ .ReleaseName }} ({{ .ReleaseDate }})](https://github.com/{{ .Repo }}/releases/tag/{{ .ReleaseName }})
+- **[{{ .Repo }} {{ .ReleaseName }}](https://github.com/{{ .Repo }}/releases/tag/{{ .ReleaseName }})** ({{ .ReleaseDate }})
+{{- end }}
+
+## Upgrade Instructions
+
+Upgrade instructions are available for the following components:
+{{ range .Components }}
+{{- if .UpgradeURL }}
+- [{{ .Repo }}]({{ .UpgradeURL }})
+{{- end }}
 {{- end }}
 
 ## Changes

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -60,6 +60,7 @@ func TestTemplates(t *testing.T) {
 				Repo:        "cyberark/conjur",
 				ReleaseName: "v1.4.4",
 				ReleaseDate: date2.Format("2006-01-02"),
+				UpgradeURL:  "https://conjur_upgrade_url",
 				Changelogs: []*changelog.VersionChangelog{
 					&changelog.VersionChangelog{
 						Repo:    "cyberark/conjur",

--- a/templates/testdata/RELEASE_NOTES_unified.md
+++ b/templates/testdata/RELEASE_NOTES_unified.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## Table of Contents
 
 - [Components](#components)
+- [Upgrade Instructions](#upgrade-instructions)
 - [Changes](#changes)
 
 ## Components
@@ -13,8 +14,14 @@ All notable changes to this project will be documented in this file.
 These are the components that combine to create this Conjur OSS Suite release and links
 to their releases:
 
-- [cyberark/conjur v1.4.4 (2020-01-03)](https://github.com/cyberark/conjur/releases/tag/v1.4.4)
-- [cyberark/secretless-broker v1.4.2 (2020-01-08)](https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2)
+- **[cyberark/conjur v1.4.4](https://github.com/cyberark/conjur/releases/tag/v1.4.4)** (2020-01-03)
+- **[cyberark/secretless-broker v1.4.2](https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2)** (2020-01-08)
+
+## Upgrade Instructions
+
+Upgrade instructions are available for the following components:
+
+- [cyberark/conjur](https://conjur_upgrade_url)
 
 ## Changes
 


### PR DESCRIPTION
This PR adds any upgrade instructions to the generated release notes. Minor adjustment was made to readability of release notes to make the components easier to visually parse too.