### PR TITLE
Add version diffing for multiple repository files

### DIFF
--- a/cmd/changelog-parser/main.go
+++ b/cmd/changelog-parser/main.go
@@ -221,7 +221,7 @@ func runParser(options cliOptions) {
 
 	if options.OutputType == "unreleased" {
 		// This is an in-place operation
-		repositories.SelectUnreleased(&repoConfig)
+		repoConfig.SelectUnreleased()
 	}
 
 	log.Printf("Collecting changelogs...")

--- a/pkg/repositories/testdata/repositories_current.yml
+++ b/pkg/repositories/testdata/repositories_current.yml
@@ -1,0 +1,28 @@
+---
+section:
+  name: Section Name
+  description: Section Description
+  categories:
+    - name: Category1
+      description: Category1 Description
+      repos:
+        - name: Repo1 Name
+          url: Repo1 URL
+          description: Repo1 Description
+          version: Repo1 Version
+          after: Repo1 After Version
+          upgrade_url: Repo1 Upgrade Url
+          certification: Repo1 Certification
+        - name: Repo2 Name
+          url: Repo2 URL
+          description: Repo2 Description
+          version: Repo2 Version
+    - name: Category2
+      description: Category2 Description
+      repos:
+        - name: Repo3 Name
+          url: Repo3 URL
+          description: Repo3 Description
+          version: Repo3 Version
+          upgrade_url: Repo3 Upgrade Url
+          certification: Repo3 Certification

--- a/pkg/repositories/testdata/repositories_new.yml
+++ b/pkg/repositories/testdata/repositories_new.yml
@@ -1,0 +1,12 @@
+---
+section:
+  name: Section Name
+  description: Section Description
+  categories:
+  - name: Category1
+    description: Category1 Description
+    repos:
+      - name: Repo2 Name
+        url: Repo2 URL
+        description: Repo2 Description
+        version: Repo2 New Version


### PR DESCRIPTION
- If a secondary repository.yml file is passed in,
we extract the repositories from the new (secondary) repository.yml
to compare against the current (first) repository.yml
- If a repository in the current file is also in the new file, based on
having identical URLs, we set the version of the current repository data
to the new version in the new file