### PR TITLE
Adding test 0.0.0 suite release versions to YAML

### DIFF
--- a/repositories.yml
+++ b/repositories.yml
@@ -3,27 +3,27 @@ section:
   name: Conjur OSS Suite Release
   description: These are the primary repositories for Conjur Open Source and its SDK.
   categories:
-  - name: Conjur OSS Core
-    description: Conjur OSS Server and Deployment Tools
+  - name: Conjur Server
+    description: Conjur Core and Deployment Tools
     repos:
       - name: cyberark/conjur
         url: https://github.com/cyberark/conjur
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         certification: "certified"
-        after: v1.3.5
+        version: v1.4.4
         upgrade_url: https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
         version: v1.3.7
-      - name: cyberark/secretless-broker
-        url: https://github.com/cyberark/secretless-broker
-        description: Secretless Broker is a connection broker which relieves client applications of the need to directly handle secrets to target services such as databases, web services, SSH connections, or any other TCP-based service.
-        version: v1.4.2
+        certification: "trusted"
 #      - name: cyberark/conjur-aws
 #        url: https://github.com/cyberark/conjur-aws
 #        description: AWS CloudFormation templates for deploying Conjur OSS.
+#        certification: "community"
+#        version: nil # No tags, can't include in release
+
   - name: Conjur SDK
     description: Conjur Command Line Interface (CLI) and Client Libraries
     repos:
@@ -31,21 +31,148 @@ section:
         url: https://github.com/cyberark/conjur-cli
         description: Conjur Ruby CLI
         certification: "certified"
-        version: v6.2.1
-#      - name: cyberark/conjur-api-dotnet
-#        url: https://github.com/cyberark/conjur-api-dotnet
-#        description: Conjur .Net Client Library
+        version: v6.2.0
+      - name: cyberark/conjur-api-dotnet
+        url: https://github.com/cyberark/conjur-api-dotnet
+        description: Conjur .Net Client Library
+        certification: "community"
+        version: v1.1.1
       - name: cyberark/conjur-api-go
         url: https://github.com/cyberark/conjur-api-go
         description: Conjur Golang Client Library
+        certification: "certified"
+        version: v0.5.2
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
+        certification: "community"
+        version: v1.1
       - name: cyberark/conjur-api-python3
         url: https://github.com/cyberark/conjur-api-python3
         description: Conjur Python Client Library
         certification: "community"
+        version: v0.0.5
       - name: cyberark/conjur-api-ruby
         url: https://github.com/cyberark/conjur-api-ruby
         description: Conjur Ruby Client Library
-        version: v4.10.2
+        version: v5.3.0
+        certification: "certified"
+
+  # This section goes back two versions to help ensure our logic for computing
+  # CHANGELOG diffs works when there are multiple versions between the latest
+  # and the pinned version.
+  # TODO: remove this comment when preparing for the first official release.
+  - name: Platform Integrations
+    description: Tools for Conjur integrations with platforms and cloud providers.
+    repos:
+      - name: cyberark/conjur-authn-k8s-client
+        url: https://github.com/cyberark/conjur-authn-k8s-client
+        tool: Kubernetes
+        description: The Conjur authenticator client can be deployed as a sidecar
+          or init container to ensure your application has a valid Conjur access token.
+        certification: "certified"
+        version: v0.15.0
+      - name: cyberark/secrets-provider-for-k8s
+        url: https://github.com/cyberark/secrets-provider-for-k8s
+        tool: Kubernetes
+        description: The Conjur Secrets Provider for K8s is deployed as an init
+          container in your application pod. It injects secrets from Conjur
+          into Kubernetes secrets, which are accessible to your application pod.
+        certification: "certified"
+        version: v0.2.0
+      - name: cyberark/conjur-service-broker
+        url: https://github.com/cyberark/conjur-service-broker
+        tool: Cloud Foundry
+        description: The Conjur service broker ensures your Cloud Foundry-deployed
+          applications are bootstrapped with a Conjur machine identity on deploy.
+        certification: "certified"
+        version: v1.0.0
+      - name: cyberark/cloudfoundry-conjur-buildpack
+        url: https://github.com/cyberark/cloudfoundry-conjur-buildpack
+        tool: Cloud Foundry
+        description: The Conjur buildpack brings the benefit of Summon to
+          your Cloud Foundry-deployed applications. Leverage your app's Conjur identity
+          to automatically inject the secrets your app needs into its environment
+          at runtime.
+        certification: "certified"
+        version: v2.1.1
+
+  - name: DevOps Tools
+    description: Conjur OSS integrations with DevOps tools.
+    repos:
+      - name: cyberark/ansible-conjur-host-identity
+        url: https://github.com/cyberark/ansible-conjur-host-identity
+        tool: Ansible
+        description: Ansible role to provide Conjur machine identity to application
+          hosts and install the Summon tool, which enables hosts to securely retrieve
+          credentials.
+        certification: "trusted"
+        version: v0.3.0
+      - name: cyberark/conjur-credentials-plugin
+        url: https://github.com/cyberark/conjur-credentials-plugin
+        tool: Jenkins
+        description: Conjur plugin for securely providing credentials to Jenkins jobs.
+        certification: "community"
+        version: v0.7
+      - name: cyberark/conjur-puppet
+        url: https://github.com/cyberark/conjur-puppet
+        tool: Puppet
+        description: Puppet module that simplifies the operation of establishing
+          Conjur host identity and allows authorized Puppet nodes to fetch secrets
+          from Conjur.
+        certification: "trusted"
+        version: v2.0.1
+      - name: cyberark/terraform-provider-conjur
+        url: https://github.com/cyberark/terraform-provider-conjur
+        tool: Terraform
+        description: Terraform provider that makes secrets in Conjur available in
+          Terraform manifests.
+        certification: "certified"
+        version: v0.1.0
+
+  - name: Secretless Broker
+    description: Secure your apps by making them Secretless.
+    repos:
+      - name: cyberark/secretless-broker
+        url: https://github.com/cyberark/secretless-broker
+        description: Secretless Broker can be used to securely connect your
+          applications to services they need - without ever having to fetch or
+          manage passwords and keys.
+        certification: "certified"
+        version: v1.5.1
+
+  - name: Summon
+    description: Run your processes wrapped with Summon to ensure they have
+      the secrets they need.
+    repos:
+      - name: cyberark/summon
+        url: https://github.com/cyberark/summon
+        description: Summon is a secure tool to inject secrets into a subprocess
+          environment.
+        certification: "certified"
+        version: v0.8.0
+      - name: cyberark/summon-aws-secrets
+        url: https://github.com/cyberark/summon-aws-secrets
+        description: Summon provider for AWS Secrets Manager.
+        certification: "community"
+        version: v0.2.0
+      - name: cyberark/summon-chefapi
+        url: https://github.com/cyberark/summon-chefapi
+        description: Summon provider for Chef encrypted data bags.
+        certification: "community"
+        version: v0.1.0
+      - name: cyberark/summon-conjur
+        url: https://github.com/cyberark/summon-conjur
+        description: Summon provider for Conjur.
+        certification: "certified"
+        version: v0.5.2
+      - name: cyberark/summon-keyring
+        url: https://github.com/cyberark/summon-keyring
+        description: Summon provider for cross-platform keyrings.
+        certification: "community"
+        version: v0.2.0
+      - name: cyberark/summon-s3
+        url: https://github.com/cyberark/summon-s3
+        description: Summon provider for AWS S3.
+        certification: "community"
+        version: v0.1.0


### PR DESCRIPTION
To enable testing of the suite release processes, we're updating the suite release YAML
to include the basic set of projects we expect might be included, and marking them all
to be at a version one below their latest

Note - the final suite release may include different versions of tools and a different set of
tools entirely - this draft file should not be taken as the plan for the official release

Each entry in this YAML should have a `version` and a `certification`.