### PR TITLE
Fixup action naming and logic

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,15 +1,15 @@
+name: Create Draft Release
 on:
   push:
     # We trigger this workflow on tag pushes that match v* (eg. `v1.2.3`)
     tags:
       - 'v*'
 
-name: Create Draft Release
 jobs:
   # This job name must match the `needs` field in `release` step
   run-tests:
     # This is mostly a copy/paste from test.yml
-    name: Tests
+    name: Run Unit Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +28,7 @@ jobs:
       run: go test -v -coverprofile=c.out -count=1 ./...
 
   release:
-    name: Release
+    name: Create Draft Release
     runs-on: ubuntu-latest
 
     needs: run-tests

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Capture release notes into a variable
       id: release_notes
       run: |
-        CONTENT=$(cat RELEASE_NOTES.md)
+        CONTENT=$(cat tmp_RELEASE_NOTES.md)
         echo "::set-output name=content::${CONTENT//$'\n'/%0A}"
 
     - name: Create Release

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - 'v*'
 
-name: Create Release
+name: Create Draft Release
 jobs:
   # This job name must match the `needs` field in `release` step
   run-tests:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,17 @@
 name: E2E Tests
 
-on: push
+on:
+  # Only run this on pushes to master
+  push:
+    branches:
+    - master
+
+  # And when PRs operations are done
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
 
 jobs:
   release-tests:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-name: Release tests
+name: E2E Tests
 
 on: push
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,8 @@ on:
     - synchronize
 
 jobs:
-  release-tests:
+  e2e-tests:
+    name: Run E2E Tests
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.13

--- a/.github/workflows/release-publish-suite-commit.yml
+++ b/.github/workflows/release-publish-suite-commit.yml
@@ -1,10 +1,12 @@
+name: Commit Released Suite YAML
 on:
   release:
     types:
       - published
 
 jobs:
-  release-tests:
+  e2e-tests:
+    name: Run E2E Tests
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.13
@@ -29,8 +31,9 @@ jobs:
         run: ./test
 
   persist-new-suite-yml:
+    name: Commit Suite Release YML
     runs-on: ubuntu-latest
-    needs: release-tests
+    needs: e2e-tests
 
     steps:
     - name: Checkout repo

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   test:
-    name: Tests
+    name: Run Tests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Unit Tests
 on:
   # Only run this on pushes to master
   push:


### PR DESCRIPTION
Included here:
- Action `release` -> `draft-release`
- Action `test` -> `unit-tests`
- Action `release-test` -> `e2e-tests`
- Fixed issues with `release` action logic paths
- Made E2E tests run on PRs and master branch only
- Made job/action naming consistent