### PR TITLE
On post-release workflow, open a PR instead of pushing to master

### DIFF
--- a/.github/workflows/release-publish-suite-commit.yml
+++ b/.github/workflows/release-publish-suite-commit.yml
@@ -66,4 +66,4 @@ jobs:
 
     - name: Push files
       run: |
-        git push "https://${{ github.actor }}:${{secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}.git" HEAD:master
+        git push "https://${{ github.actor }}:${{secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}.git" "HEAD:suite_${version}"

--- a/.github/workflows/update-suite-release-pr.yml
+++ b/.github/workflows/update-suite-release-pr.yml
@@ -1,4 +1,4 @@
-name: Commit Released Suite YAML
+name: Open PR for Releases Update
 on:
   release:
     types:
@@ -46,24 +46,39 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
 
-    - name: Permanently save the new suite release
+    - name: Set BRANCH_NAME
       run: |
-        mkdir -p releases
-
         tag_name=${{github.event.release.tag_name}}
         echo "Tag: $tag_name"
 
         version=$(echo "$tag_name" | sed 's/^v//')
         echo "Version: $version"
 
-        new_suite_version_yml="releases/suite_${version}.yml"
+        echo "::set-output name=suite_version::${version}"
+        echo "::set-output name=suite_update_branch::suite_${version}"
+      id: data
+
+    - name: Permanently save the new suite release
+      run: |
+        mkdir -p releases
+
+        new_suite_version_yml="releases/suite_${{ steps.data.outputs.suite_version }}.yml"
         echo "Suite target file: $new_suite_version_yml"
 
         cp suite.yml "${new_suite_version_yml}"
 
         git add "${new_suite_version_yml}"
-        git commit -m "Release ${version} auto-commit of new release"
+        git commit -m "Suite v${{ steps.data.outputs.suite_version }} auto-commit of new release files"
 
     - name: Push files
       run: |
-        git push "https://${{ github.actor }}:${{secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}.git" "HEAD:suite_${version}"
+        git push --force "https://${{ github.actor }}:${{secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}.git" "HEAD:${{ steps.data.outputs.suite_update_branch }}"
+
+    - name: Open a PR to the default branch
+      uses: vsoch/pull-request-action@d987bc1 # Pinned v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PULL_REQUEST_FROM_BRANCH: "${{ steps.data.outputs.suite_update_branch }}"
+        PULL_REQUEST_BRANCH: master
+        PULL_REQUEST_TITLE: "Action: Update suite release file for v${{ steps.data.outputs.suite_version }}"
+        PULL_REQUEST_BODY: "Auto-generated PR!"

--- a/.github/workflows/update-suite-release-pr.yml
+++ b/.github/workflows/update-suite-release-pr.yml
@@ -5,35 +5,9 @@ on:
       - published
 
 jobs:
-  e2e-tests:
-    name: Run E2E Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Create k8s KinD Cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
-
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-
-      - name: Add Helm 'stable' repository
-        run: helm repo add stable https://kubernetes-charts.storage.googleapis.com/ && helm repo update
-
-      - name: Run releases test
-        working-directory: ./release-testing
-        run: ./test
-
   persist-new-suite-yml:
     name: Commit Suite Release YML
     runs-on: ubuntu-latest
-    needs: e2e-tests
 
     steps:
     - name: Checkout repo


### PR DESCRIPTION
Since master is protected, this change will allow us to auto-open a PR with those changes from a separate branch.