### PR TITLE
Logging levels for E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,3 +38,8 @@ jobs:
       - name: Run releases test
         working-directory: ./release-testing
         run: ./test
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: debug-log
+          path: ./release-testing/debug-log.txt

--- a/cmd/changelog-parser/main_test.go
+++ b/cmd/changelog-parser/main_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/cyberark/conjur-oss-suite-release/pkg/log"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -48,7 +49,7 @@ func TestMain(t *testing.T) {
 				Version:            "Unreleased",
 			})
 
-			log.Print("Verifying test result...")
+			log.OutLogger.Print("Verifying test result...")
 
 			outputFileContent, err := ioutil.ReadFile(outputFile)
 			if !assert.NoError(t, err) {
@@ -121,7 +122,7 @@ func TestGenerateOutputFilename(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run("GenerateOutputFilename: " + tc.description, func(t *testing.T) {
+		t.Run("GenerateOutputFilename: "+tc.description, func(t *testing.T) {
 			tc.options.generateOutputFilename()
 
 			assert.EqualValues(t, tc.expectedFilename, tc.options.OutputFilename)

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -3,8 +3,9 @@ package github
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
+
+	"github.com/cyberark/conjur-oss-suite-release/pkg/log"
 
 	"github.com/cyberark/conjur-oss-suite-release/pkg/http"
 )
@@ -51,7 +52,7 @@ func getAvailableReleases(
 		releaseVersions[index] = release.TagName
 	}
 
-	log.Printf("  Available versions: [%s]", strings.Join(releaseVersions, ", "))
+	log.OutLogger.Printf("  Available versions: [%s]", strings.Join(releaseVersions, ", "))
 
 	return releaseVersions, nil
 }

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -3,8 +3,9 @@ package http
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	stdlibHttp "net/http"
+
+	"github.com/cyberark/conjur-oss-suite-release/pkg/log"
 )
 
 // Client is a wrapper around stdlibHttp client but with added storage for
@@ -35,7 +36,7 @@ func (client *Client) Get(url string) ([]byte, error) {
 		request.Header.Add("Authorization", "token "+client.AuthToken)
 	}
 
-	log.Printf("  Fetching %s...", url)
+	log.OutLogger.Printf("  Fetching %s...", url)
 	response, err := client.Do(request)
 	if err != nil {
 		return nil, err

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,12 @@
+package log
+
+import (
+	"log"
+	"os"
+)
+
+// ErrLogger is a logger than write to /dev/stderr
+var ErrLogger = log.New(os.Stderr, "", log.LstdFlags)
+
+// OutLogger is a logger than write to /dev/stdout
+var OutLogger = log.New(os.Stdout, "", log.LstdFlags)

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -3,7 +3,8 @@ package repositories
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+
+	"github.com/cyberark/conjur-oss-suite-release/pkg/log"
 
 	"gopkg.in/yaml.v3"
 )
@@ -42,13 +43,13 @@ type Config struct {
 // NewConfig ingests a YAML file and returns a Config representing the definitions
 // in that file.
 func NewConfig(filename string) (Config, error) {
-	log.Printf("Reading %s...", filename)
+	log.OutLogger.Printf("Reading %s...", filename)
 	yamlFile, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return Config{}, fmt.Errorf("error reading YAML file: %s", err)
 	}
 
-	log.Printf("Unmarshaling data...")
+	log.OutLogger.Printf("Unmarshaling data...")
 	var repoConfig Config
 	err = yaml.Unmarshal(yamlFile, &repoConfig)
 	if err != nil {

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -3,7 +3,6 @@ package template
 import (
 	"fmt"
 	htmlTemplate "html/template"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cyberark/conjur-oss-suite-release/pkg/changelog"
+	"github.com/cyberark/conjur-oss-suite-release/pkg/log"
 )
 
 // SuiteComponent represents a suite component with all of its changelogs and
@@ -92,7 +92,7 @@ func (engine *Engine) renderTemplate(
 		return fmt.Errorf("Could not read template '%s'", templatePath)
 	}
 
-	log.Printf("Generating '%s' file from template '%s'...", outputFile.Name(), templatePath)
+	log.OutLogger.Printf("Generating '%s' file from template '%s'...", outputFile.Name(), templatePath)
 
 	// Sadly while `html/template` and `text/template` share the same API, they
 	// use incompatible signatures and parameters so depending on the extension,
@@ -126,7 +126,7 @@ func (engine *Engine) WriteChangelog(
 	outputPath string) error {
 
 	// Open the target file
-	log.Printf("Opening '%s'...", outputPath)
+	log.OutLogger.Printf("Opening '%s'...", outputPath)
 	outputFile, err := os.Create(outputPath)
 	if err != nil {
 		return fmt.Errorf("Error creating %s: %v", outputPath, err)

--- a/release-testing/kv/cmd/main.go
+++ b/release-testing/kv/cmd/main.go
@@ -4,11 +4,12 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/rpc"
 	"os"
+
+	"github.com/cyberark/conjur-oss-suite-release/pkg/log"
 
 	"test/kv"
 )
@@ -134,23 +135,23 @@ func fatal(msg string) {
 }
 
 func runServer() {
-	log.Println("#Serve")
+	log.OutLogger.Println("#Serve")
 
 	err := rpc.Register(kv.Store{})
 	if err != nil {
-		log.Fatal("register error: " + err.Error())
+		log.ErrLogger.Fatal("register error: " + err.Error())
 	}
 
 	rpc.HandleHTTP()
 	l, err := net.Listen("tcp", "localhost:")
 	if err != nil {
-		log.Fatal("listen error:", err)
+		log.ErrLogger.Fatal("listen error:", err)
 	}
 
-	log.Println("Using port:", l.Addr().(*net.TCPAddr).Port)
+	log.OutLogger.Println("Using port:", l.Addr().(*net.TCPAddr).Port)
 
 	err = http.Serve(l, nil)
 	if err != nil {
-		log.Fatal("serve error:", err)
+		log.ErrLogger.Fatal("serve error:", err)
 	}
 }

--- a/release-testing/kv/store.go
+++ b/release-testing/kv/store.go
@@ -3,8 +3,9 @@ package kv
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
+
+	"github.com/cyberark/conjur-oss-suite-release/pkg/log"
 )
 
 // Store is an in-memory key-value store
@@ -23,7 +24,7 @@ type GetArg struct {
 
 // Set inserts a key-value pair into the store
 func (s Store) Set(arg SetArg, _ *int) error {
-	log.Println("#Set")
+	log.OutLogger.Println("#Set")
 
 	s[arg.Key] = arg.Value
 	return nil
@@ -32,7 +33,7 @@ func (s Store) Set(arg SetArg, _ *int) error {
 // Get retrieves a value from the store, given a key.
 // It returns an error if the key does not exist
 func (s Store) Get(arg GetArg, reply *string) error {
-	log.Println("#Get")
+	log.OutLogger.Println("#Get")
 
 	val, ok := s[arg.Key]
 	if !ok {
@@ -45,7 +46,7 @@ func (s Store) Get(arg GetArg, reply *string) error {
 
 // List returns a slice of strings containing each of the keys present in the store
 func (s Store) List(arg int, reply *[]string) error {
-	log.Println("#List")
+	log.OutLogger.Println("#List")
 
 	var keys []string
 	for key := range s {
@@ -58,7 +59,7 @@ func (s Store) List(arg int, reply *[]string) error {
 
 // Snapshot returns a JSON serialized string of the Store at the moment the call is made
 func (s Store) Snapshot(arg int, reply *string) error {
-	log.Println("#Snapshot")
+	log.OutLogger.Println("#Snapshot")
 
 	res, err := json.Marshal(s)
 	*reply = string(res)
@@ -68,7 +69,7 @@ func (s Store) Snapshot(arg int, reply *string) error {
 
 // Destroy kills the process with 0 exit code
 func (s Store) Destroy(arg int, _ *int) error {
-	log.Println("#Destroy")
+	log.OutLogger.Println("#Destroy")
 	os.Exit(0)
 	return nil
 }

--- a/release-testing/policy.yml.sh
+++ b/release-testing/policy.yml.sh
@@ -41,7 +41,7 @@ echo "
     description: Identities permitted to authenticate
   body:
 
-  # define layer of whitelisted authn ids permitted to call authn service
+  # Define layer of whitelisted authn ids permitted to call authn service
   - !layer
     annotations:
       description: Layer of authenticator identities permitted to call authn svc
@@ -84,7 +84,7 @@ echo "
       privileges: [ read, execute ]
       resources: *variables
 
-# add authn identities to application layer so authn roles inherit app's permissions
+# Add authn identities to application layer so authn roles inherit app's permissions
 - !grant
   role: !layer test-app
   members:

--- a/release-testing/secretless_test.go
+++ b/release-testing/secretless_test.go
@@ -48,7 +48,7 @@ exec_conjur_client conjur variable values add test-app-secrets/username ` + expe
 		out, err := callBashScript(
 			// language=bash
 			`
-exec_app bash -c '
+exec_app bash -exc '
 export http_proxy=http://localhost:8080
 
 curl -s "http://httpbin.org/anything" | jq -j ".headers.Authorization"

--- a/release-testing/store-component-versions.go
+++ b/release-testing/store-component-versions.go
@@ -3,9 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"strings"
 
+	"github.com/cyberark/conjur-oss-suite-release/pkg/log"
 	"github.com/cyberark/conjur-oss-suite-release/pkg/repositories"
 )
 
@@ -16,20 +16,20 @@ func main() {
 
 	if suiteFile == "" {
 		flag.PrintDefaults()
-		log.Fatal("missing required -f flag")
+		log.ErrLogger.Fatal("missing required -f flag")
 		return
 	}
 
 	repoConfig, err := repositories.NewConfig(suiteFile)
 	if err != nil {
-		log.Fatal(err)
+		log.ErrLogger.Fatal(err)
 		return
 	}
 
 	for _, categories := range repoConfig.Section.Categories {
 		for _, repo := range categories.Repos {
 			key := fmt.Sprintf("RELEASE.%s.VERSION", strings.ToUpper(repo.Name))
-			log.Println("Setting store value for key: " + key)
+			log.OutLogger.Println("Setting store value for key: " + key)
 
 			err = storeClient.Set(
 				key,
@@ -37,7 +37,7 @@ func main() {
 			)
 
 			if err != nil {
-				log.Fatal(err)
+				log.ErrLogger.Fatal(err)
 				return
 			}
 		}

--- a/release-testing/store.sh
+++ b/release-testing/store.sh
@@ -49,7 +49,7 @@ function store_snapshot() {
 
 # store_cleanup snapshots then destroys the store
 function store_cleanup() {
-  # inherit exit_code or use $?
+  # Inherit exit_code or use $?
   local exit_code="${exit_code:-$?}"
 
   if [[ ! "${exit_code}" = 0 ]]; then

--- a/release-testing/test
+++ b/release-testing/test
@@ -1,5 +1,39 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+
+# Set up logging
+#
+# The following setup creates log levels; info and debug. It forces all output, by
+# default, to the debug logfile.
+#
+# 1. The info logfile is simply a file that can be copied to the original stdout by
+# tailing it via a background process (see below) i.e. `tail -f info-log.txt &`
+# 2. Redirect stdout, stderr and xtrace to the debug logfile.
+# 3. Any output for information purposes should be written to the info logfile e.g.
+# `command >> info-log.txt`.
+# 4. To write to both info and debug use tee, making sure to append, i.e.
+# `command | tee -a info-log.txt`.
+
+# Reset logfiles
+printf '' > info-log.txt > debug-log.txt > error-log.txt
+# Begin by tailing the info logfile as a background process so that the contents of the
+# info logfile are output to stdout. A trap, further down, ensures this process is
+# cleaned-up when this script exits.
+tail -f info-log.txt &
+
+# Redirect stdout to append to debug logfile
+exec 1>>debug-log.txt
+# Redirect stderr to append to debug logfile and overwrite to error logfile
+# The error logfile maintains the last write to stderr. It can be used to offer useful
+# context to a failure before digging into the debug logs
+exec 2>> >(tee -a debug-log.txt > error-log.txt)
+# Create a file descriptor for capturing xtrace. This allows us to seperate the xtrace logs
+# from stdout and stderr
+exec 3>>debug-log.txt
+# Set the script's xtrace file descriptor to the one created above (3)
+export BASH_XTRACEFD="3"
+
+# Start script
+set -xeuo pipefail
 
 cd "$(dirname "$0")"
 
@@ -16,16 +50,10 @@ function reset_infra() {
 }
 
 function complete_cleanup() {
-  # inherit exit_code or use $?
-  local exit_code="${exit_code:-$?}"
-  export exit_code
-
   local TEST_NAMESPACE
   TEST_NAMESPACE="$(store_get TEST_NAMESPACE || true)"
 
-  echo "Cleaning up."
-
-  # snapshot of workloads
+  # Snapshot of workloads
   kubectl --namespace "${TEST_NAMESPACE}" get pods || true
   kubectl --namespace "${TEST_NAMESPACE}" get events --field-selector type=Warning || true
 
@@ -49,13 +77,53 @@ function store_set_component_versions() {
   store_set SECRETLESS_RELEASE_VERSION "${SECRETLESS_RELEASE_VERSION}"
 }
 
+function cleanup() {
+  # Inherit exit_code or use $?
+  local exit_code="${exit_code:-$?}"
+  export exit_code
+
+  if [[ ! "${exit_code}" = "0" ]]; then
+    {
+      echo ""
+      echo "<< START: Last output to stderr"
+      cat error-log.txt
+      echo "<< END: Last output to stderr"
+      echo ""
+      echo "Non-zero exit code. 😞 "
+      echo ""
+      echo "For some contextual info look above from 'START: Last output to stderr'."
+      echo "You can also consult debug-log.txt to see the verbose logs."
+      echo ""
+    } >> info-log.txt
+  else
+    echo "Success. 🚀 " >> info-log.txt
+  fi
+
+  echo "Cleaning up." | tee -a info-log.txt
+  _cleanup || true
+  pkill -P $$
+}
+
+function _cleanup() {
+  echo "_cleanup is set to the default, which does nothing :(" | tee -a info-log.txt
+}
+
 function main() {
-  # exit cleans up only store, at this point, because nothing else has been created
-  trap "store_cleanup" EXIT
+  trap "cleanup" EXIT
+
+  # Ensure test go modules are downloaded
+  echo -n "Download go modules for release tests." | tee -a info-log.txt
+  go mod download
+  echo " ✅ " | tee -a info-log.txt
+
+  # Exit cleans up only store, at this point, because nothing else has been created
+  function _cleanup() {
+    store_cleanup
+  }
 
   store_init
 
-  # extract component version from suite.yml in root directory
+  # Extract component version from suite.yml in root directory
   store_set_component_versions
 
   local TEST_NAMESPACE
@@ -83,15 +151,19 @@ function main() {
 
   store_set CLI_POD_NAME "test-client"
 
-  # exit should now result in complete cleanuip
-  trap "complete_cleanup" EXIT
+  # Exit should now result in complete cleanup
+  function _cleanup() {
+    complete_cleanup
+  }
+
   reset_infra
 
-  # setup infrastructure for testing
+  # Setup infrastructure for testing
   ./prepare.sh
 
-  # execute test cases
-  go test -v -count=1 --tags=release_test ./...
+  # Execute test cases
+  echo "Execute test cases." | tee -a info-log.txt
+  go test -v -count=1 --tags=release_test ./... | tee -a info-log.txt
 }
 
 main


### PR DESCRIPTION
Using some redirection it's possible to selectively log steps in the release test scripts. This makes it possible to have info logs on stdout and debug logs on file. The debug logs can be consulted on failure.