### PR TITLE
Added error checking to `cli.RunParser` tests of main.go

### DIFF
--- a/cmd/changelog-parser/main_test.go
+++ b/cmd/changelog-parser/main_test.go
@@ -42,13 +42,16 @@ func TestMain(t *testing.T) {
 			outputDate, _ := time.Parse(time.RFC3339, "2020-02-19T12:00:00Z")
 
 			// Run the test
-			cli.RunParser(cli.Options{
+			err = cli.RunParser(cli.Options{
 				Date:               outputDate,
 				OutputFilename:     outputFile,
 				OutputType:         tt,
 				RepositoryFilename: testRepositoriesYml,
 				Version:            "Unreleased",
 			})
+			if !assert.NoError(t, err) {
+				return
+			}
 
 			log.OutLogger.Print("Verifying test result...")
 


### PR DESCRIPTION
Old code would silently eat the errors but now we ensure that we check
and print the errors if they happen.