### PR TITLE
fix: Helm version in e2e-tests workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: 3.1.2
+          version: v3.1.2
 
       - name: Add Helm 'stable' repository
         run: helm repo add stable https://kubernetes-charts.storage.googleapis.com/ && helm repo update


### PR DESCRIPTION
The helm version needs to be prefixed with a 'v'.