### PR TITLE
Update unit-tests workflow to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,6 +40,8 @@ jobs:
         ./cc-test-reporter before-build
 
     - name: Run Tests
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: go test -v -coverprofile=c.out -count=1 ./...
 
     - name: Submit CC Report


### PR DESCRIPTION
This avoids the API rate limit exceeded error from the Github API