### PR TITLE
112 - HTML Template Output Converts Markdown Tags to HTML Anchors

### DIFF
--- a/pkg/cli/testdata/expected_docs-release_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_output.txt
@@ -110,7 +110,7 @@ from the id.</li>
           <ul>
               <li><strong>Added</strong>
                 <ul>
-                  <li>Added ability to delete policies [#23](https://github.com/cyberark/conjur-api-python3/issues/23)</li>
+                  <li>Added ability to delete policies <a href="https://github.com/cyberark/conjur-api-python3/issues/23">#23</a></li>
                 </ul>
               </li>
           </ul>

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -132,3 +132,40 @@ func TestWriteChangelogTemplateResolutionError(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkdownHyperlinksToHTMLHyperlinks(t *testing.T) {
+	testData := []struct {
+		description    string
+		inputString    string
+		expectedString string
+	}{
+		{
+			description:    "no url in input",
+			inputString:    "foo",
+			expectedString: "foo",
+		},
+		{
+			description:    "input includes words in perentheses",
+			inputString:    "foo (bar)",
+			expectedString: "foo (bar)",
+		},
+		{
+			description:    `input contains a single url`,
+			inputString:    `foo [bar](baz)`,
+			expectedString: `foo <a href="baz">bar</a>`,
+		},
+		{
+			description:    `input contains multiple urls`,
+			inputString:    `foo [bar](baz) & [jack](box)`,
+			expectedString: `foo <a href="baz">bar</a> & <a href="box">jack</a>`,
+		},
+	}
+
+	for _, td := range testData {
+		t.Run(td.description, func(t *testing.T) {
+			actualString := markdownHyperlinksToHTMLHyperlinks(td.inputString)
+
+			assert.EqualValues(t, td.expectedString, actualString)
+		})
+	}
+}

--- a/templates/RELEASE_NOTES_unified.htm.tmpl
+++ b/templates/RELEASE_NOTES_unified.htm.tmpl
@@ -48,7 +48,7 @@
               <li><strong>{{ $sectionKey }}</strong>
                 <ul>
                 {{- range $sectionItem := $sectionValues }}
-                  <li>{{ $sectionItem -}}</li>
+                  <li>{{ markdownHyperlinksToHTMLHyperlinks $sectionItem -}}</li>
                 {{- end }}
                 </ul>
               </li>


### PR DESCRIPTION
If a markdown-type link is found in a changelog list item, it
is replaced with an HTML anchor

- Introduced a new function map function for the template
generator, called markdownHyperlinksToHTMLHyperlinks
- Added unit test for markdownHyperlinksToHTMLHyperlinks
- Updated test output for docs-release testing