### PR TITLE
133 `latest` release resolution fix

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -79,6 +79,33 @@ func LatestReleaseInDir(releasesDir string) (string, error) {
 	return highestReleasePath, nil
 }
 
+// HighestVersion returns the highest version string from an array of
+// version strings
+func HighestVersion(versions []string) (string, error) {
+	if len(versions) == 0 {
+		return "",
+			fmt.Errorf("cannot ascertain highest version - no versions provided")
+	}
+
+	highestVersion, err := versionFromString(versions[0])
+	if err != nil {
+		return "", err
+	}
+
+	for _, versionStr := range versions {
+		version, err := versionFromString(versionStr)
+		if err != nil {
+			return "", err
+		}
+
+		if highestVersion.LessThan(*version) {
+			highestVersion = version
+		}
+	}
+
+	return "v" + (*highestVersion).String(), nil
+}
+
 // GetRelevantVersions sorts and returns the list of versions from highest
 // (included) to the lowest (excluded). The method auto-detects what's the
 // lower and what's the higher range bound.

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -235,3 +235,55 @@ func TestGetRelevantVersionsWithNoVersionsWithinRange(t *testing.T) {
 			"in available versions ([v1.3.4 v1.3.3 v1.20.0 v0.29.20 v0.2.0 v0.1.3])",
 	)
 }
+
+func TestHighestVersion(t *testing.T) {
+	highestVersion, err := HighestVersion(versionFixtureData)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, highestVersion, "v1.20.0")
+}
+
+func TestHighestVersionSingleVersionArg(t *testing.T) {
+	highestVersion, err := HighestVersion([]string{"v2.3.4"})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, highestVersion, "v2.3.4")
+}
+
+func TestHighestVersionNoVersionsPassedIn(t *testing.T) {
+	_, err := HighestVersion([]string{})
+	if !assert.Error(t, err) {
+		return
+	}
+
+	assert.EqualError(t, err, "cannot ascertain highest version - no versions provided")
+}
+
+func TestHighestVersionFirstVersionBadInArg(t *testing.T) {
+	_, err := HighestVersion([]string{"abcd"})
+	if !assert.Error(t, err) {
+		return
+	}
+
+	assert.EqualError(t, err, "abcd is not in dotted-tri format")
+}
+
+func TestHighestVersionBadVersionsInArg(t *testing.T) {
+	_, err := HighestVersion(
+		[]string{
+			"1.2.3",
+			"2.3.4",
+			"9",
+			"3.4.5",
+		},
+	)
+	if !assert.Error(t, err) {
+		return
+	}
+
+	assert.EqualError(t, err, "9 is not in dotted-tri format")
+}


### PR DESCRIPTION
We now tied the "semver" latest release resolution into the main code to replace
the temporal-based latest release version resolution.

Connected to #133 