### PR TITLE
140 - Update templates to ignore empty changelogs

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -97,34 +97,38 @@ func TestRunParserWithReleaseDiffing(t *testing.T) {
 	}
 	defer os.RemoveAll(outputDir)
 
-	outputFile := filepath.Join(outputDir, "output.txt")
-	outputDate, _ := time.Parse(time.RFC3339, "2020-02-19T12:00:00Z")
+	for _, tt := range []string{"changelog", "docs-release", "release"} {
+		t.Run(tt, func(t *testing.T) {
+			outputFile := filepath.Join(outputDir, tt+"output.txt")
+			outputDate, _ := time.Parse(time.RFC3339, "2020-02-19T12:00:00Z")
 
-	// Run the test
-	err = RunParser(Options{
-		Date:               outputDate,
-		OutputFilename:     outputFile,
-		OutputType:         "release",
-		RepositoryFilename: testRepositoriesYml,
-		ReleasesDir:        filepath.Join(thisDir, "testdata", "mock_releases"),
-		Version:            "Unreleased",
-	})
-	if !assert.NoError(t, err) {
-		return
+			// Run the test
+			err = RunParser(Options{
+				Date:               outputDate,
+				OutputFilename:     outputFile,
+				OutputType:         tt,
+				RepositoryFilename: testRepositoriesYml,
+				ReleasesDir:        filepath.Join(thisDir, "testdata", "mock_releases"),
+				Version:            "Unreleased",
+			})
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			outputFileContent, err := ioutil.ReadFile(outputFile)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			expectedOutputFile := filepath.Join(thisDir, "testdata", "expected_"+tt+"_diff_output.txt")
+			expectedOutput, err := ioutil.ReadFile(expectedOutputFile)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			assert.Equal(t, string(expectedOutput), string(outputFileContent))
+		})
 	}
-
-	outputFileContent, err := ioutil.ReadFile(outputFile)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	expectedOutputFile := filepath.Join(thisDir, "testdata", "expected_suite_diff_output.txt")
-	expectedOutput, err := ioutil.ReadFile(expectedOutputFile)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	assert.Equal(t, string(expectedOutput), string(outputFileContent))
 }
 
 func TestSettingOutputFilename(t *testing.T) {

--- a/pkg/cli/testdata/expected_changelog_diff_output.txt
+++ b/pkg/cli/testdata/expected_changelog_diff_output.txt
@@ -1,0 +1,29 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - 2020-02-19
+
+### Added
+- `cyberark/conjur-oss-helm-chart@1.3.8`: Added basic instructions on how to package the chart
+- `cyberark/conjur-oss-helm-chart@1.3.8`: Added gitleaks config to repo
+
+### Changed
+- `cyberark/conjur@1.4.6`: K8s hosts' application identity is extracted from annotations or id. If it is
+defined in annotations it will taken from there and if not, it will be taken
+from the id.
+- `cyberark/conjur@1.4.7`: Improved flows and rules around user creation (#1272)
+- `cyberark/conjur@1.4.7`: Kubernetes authenticator now returns 403 on unpermitted hosts instead of a 401 (#1283)
+- `cyberark/conjur@1.4.7`: Conjur hosts can authenticate with authn-k8s from anywhere in the policy branch (#1189)
+- `cyberark/conjur-oss-helm-chart@1.3.8`: Updated deployments to be able to run on Kubernetes 1.16+
+- `cyberark/conjur-oss-helm-chart@1.3.8`: Updated e2e scripts to support newest helm (v.1.3.8)
+
+### Fixed
+- `cyberark/conjur@1.4.7`: Updated broken links on server status page (#1341)
+
+### Removed
+- `cyberark/conjur-oss-helm-chart@1.3.8`: Removed GitLab pipeline (it wasn't working anyways)
+
+

--- a/pkg/cli/testdata/expected_docs-release_diff_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_diff_output.txt
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
+  <head></head>
+  <body>
+    <h1>Release Notes</h1>
+    <p>The following components were included or enhanced in the unreleased Conjur OSS suite.</p>
+
+    <h2>Components</h2>
+    <p>These are the components that comprise the Conjur Open Source Suite with links to their GitHub releases:</p>
+    <ul>
+      <li>
+        <p><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.7">cyberark/conjur v1.4.7</a> (2020-03-12)</p>
+      </li>
+      <li>
+        <p><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8">cyberark/conjur-oss-helm-chart v1.3.8</a> (2019-12-20)</p>
+      </li>
+      <li>
+        <p><a href="https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5">cyberark/conjur-api-python3 v0.0.5</a> (2019-12-06)</p>
+      </li>
+    </ul>
+
+    <h2>Upgrade Instructions</h2>
+    <p>Upgrade instructions are available for the following suite components:</p>
+    <ul>
+      <li>
+        <p><a href="https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm ">cyberark/conjur</a></p>
+      </li>
+    </ul>
+
+    <h2>What's New by Component</h2>
+    <p>The following components were introduced or enhanced in the unreleased Conjur OSS suite.</p>
+    <MadCap:listOfProxy style="mc-list-of-tag: h3;mc-list-of-class: list;mc-list-of-paragraph-class: RN;" />
+    <h3 class="list">cyberark/conjur</h3>
+      <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.6">v1.4.6</a> (2020-01-21)</h4>
+      <p><strong>Changed</strong></p>
+      <ul>
+        <li>
+          <p>K8s hosts' application identity is extracted from annotations or id. If it is
+defined in annotations it will taken from there and if not, it will be taken
+from the id.</p>
+        </li>
+      </ul>
+      <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.7">v1.4.7</a> (2020-03-12)</h4>
+      <p><strong>Changed</strong></p>
+      <ul>
+        <li>
+          <p>Improved flows and rules around user creation (#1272)</p>
+        </li>
+        <li>
+          <p>Kubernetes authenticator now returns 403 on unpermitted hosts instead of a 401 (#1283)</p>
+        </li>
+        <li>
+          <p>Conjur hosts can authenticate with authn-k8s from anywhere in the policy branch (#1189)</p>
+        </li>
+      </ul>
+      <p><strong>Fixed</strong></p>
+      <ul>
+        <li>
+          <p>Updated broken links on server status page (#1341)</p>
+        </li>
+      </ul>
+    <h3 class="list">cyberark/conjur-oss-helm-chart</h3>
+      <h4><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8">v1.3.8</a> (2019-12-20)</h4>
+      <p><strong>Added</strong></p>
+      <ul>
+        <li>
+          <p>Added basic instructions on how to package the chart</p>
+        </li>
+        <li>
+          <p>Added gitleaks config to repo</p>
+        </li>
+      </ul>
+      <p><strong>Changed</strong></p>
+      <ul>
+        <li>
+          <p>Updated deployments to be able to run on Kubernetes 1.16+</p>
+        </li>
+        <li>
+          <p>Updated e2e scripts to support newest helm (v.1.3.8)</p>
+        </li>
+      </ul>
+      <p><strong>Removed</strong></p>
+      <ul>
+        <li>
+          <p>Removed GitLab pipeline (it wasn't working anyways)</p>
+        </li>
+      </ul>
+  </body>
+</html>

--- a/pkg/cli/testdata/expected_docs-release_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_output.txt
@@ -30,7 +30,6 @@
     <h2>What's New by Component</h2>
     <p>The following components were introduced or enhanced in the unreleased Conjur OSS suite.</p>
     <MadCap:listOfProxy style="mc-list-of-tag: h3;mc-list-of-class: list;mc-list-of-paragraph-class: RN;" />
-
     <h3 class="list">cyberark/conjur</h3>
       <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.3.6">v1.3.6</a> (2019-02-19)</h4>
       <p><strong>Changed</strong></p>
@@ -97,7 +96,6 @@ defined in annotations it will taken from there and if not, it will be taken
 from the id.</p>
         </li>
       </ul>
-
     <h3 class="list">cyberark/conjur-oss-helm-chart</h3>
       <h4><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7">v1.3.7</a> (2019-01-31)</h4>
       <p><strong>Changed</strong></p>
@@ -106,7 +104,6 @@ from the id.</p>
           <p>Server ciphers have been upgraded to TLS1.2 levels.</p>
         </li>
       </ul>
-
     <h3 class="list">cyberark/conjur-api-python3</h3>
       <h4><a href="https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5">v0.0.5</a> (2019-12-06)</h4>
       <p><strong>Added</strong></p>

--- a/pkg/cli/testdata/expected_release_diff_output.txt
+++ b/pkg/cli/testdata/expected_release_diff_output.txt
@@ -87,4 +87,3 @@ from the id.
     - Updated e2e scripts to support newest helm (v.1.3.8)
 * **Removed**
     - Removed GitLab pipeline (it wasn't working anyways)
-### cyberark/conjur-api-python3

--- a/templates/RELEASE_NOTES_unified.htm.tmpl
+++ b/templates/RELEASE_NOTES_unified.htm.tmpl
@@ -32,7 +32,7 @@
     <MadCap:listOfProxy style="mc-list-of-tag: h3;mc-list-of-class: list;mc-list-of-paragraph-class: RN;" />
 
     {{- range .Components }}
-
+    {{- if ne (len .Changelogs) 0 }}
     <h3 class="list">{{ .Repo }}</h3>
       {{- range .Changelogs }}
       <h4><a href="https://github.com/{{ .Repo }}/releases/tag/v{{ .Version }}">v{{ .Version }}</a> ({{ .Date }})</h4>
@@ -45,6 +45,7 @@
         </li>
         {{- end }}
       </ul>
+      {{- end }}
       {{- end }}
       {{- end }}
     {{- end }}

--- a/templates/RELEASE_NOTES_unified.md.tmpl
+++ b/templates/RELEASE_NOTES_unified.md.tmpl
@@ -38,6 +38,7 @@ OSS Suite release:
 - [{{ .Repo }}](#{{ markdownHeaderLink .Repo }})
 {{ end -}}
 {{- range .Components }}
+{{- if ne (len .Changelogs) 0 }}
 ### {{ .Repo }}
 {{ range .Changelogs }}
 #### [v{{ .Version}}](https://github.com/{{ .Repo }}/releases/tag/v{{ .Version }}) ({{.Date }})
@@ -47,6 +48,6 @@ OSS Suite release:
     - {{ $sectionItem }}
 {{- end }}
 {{- end }}
-
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/templates/testdata/RELEASE_NOTES_unified.htm
+++ b/templates/testdata/RELEASE_NOTES_unified.htm
@@ -27,7 +27,6 @@
     <h2>What's New by Component</h2>
     <p>The following components were introduced or enhanced in the 11.22.33 Conjur OSS suite.</p>
     <MadCap:listOfProxy style="mc-list-of-tag: h3;mc-list-of-class: list;mc-list-of-paragraph-class: RN;" />
-
     <h3 class="list">cyberark/conjur</h3>
       <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.3.6">v1.3.6</a> (2020-02-01)</h4>
       <p><strong>Changed</strong></p>
@@ -70,7 +69,6 @@
           <p>144Fix</p>
         </li>
       </ul>
-
     <h3 class="list">cyberark/secretless-broker</h3>
       <h4><a href="https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2">v1.4.2</a> (2020-01-08)</h4>
       <p><strong>Added</strong></p>


### PR DESCRIPTION
- Tests added for when we run diffing against two suites,
and a repo version has not changed. In this case, we do not
write the change notes for that unchanged version. Test data
added that reflects that scenario.

- Updated templates to not create a header for categories without
any changes