### PR TITLE
Clean up dev release to prepare for 0.0.1 baseline release

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,6 +42,7 @@ jobs:
         run: ./test
 
       - uses: actions/upload-artifact@v1
+        if: failure()
         with:
           name: debug-log
           path: ./release-testing/debug-log.txt

--- a/pkg/cli/testdata/expected_changelog_output.txt
+++ b/pkg/cli/testdata/expected_changelog_output.txt
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `cyberark/conjur@1.4.4`: Early validation of account existence during OIDC authentication
 - `cyberark/conjur@1.4.4`: Code coverage reporting and collection
+- `cyberark/conjur-api-go@0.6.0`: Converted to Golang 1.12
+- `cyberark/conjur-api-go@0.6.0`: Started using os.UserHomeDir() built-in instead of go-homedir module
+- `cyberark/conjur-api-java@2.0.0`: License updated to Apache v2 - [PR #8](https://github.com/cyberark/conjur-api-java/pull/8)
 - `cyberark/conjur-api-python3@0.0.5`: Added ability to delete policies [#23](https://github.com/cyberark/conjur-api-python3/issues/23)
 
 ### Changed
@@ -20,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `cyberark/conjur@1.4.6`: K8s hosts' application identity is extracted from annotations or id. If it is
 defined in annotations it will taken from there and if not, it will be taken
 from the id.
+- `cyberark/conjur-api-java@2.0.0`: Authn tokens now use the new Conjur 5 format - [PR #21](https://github.com/cyberark/conjur-api-java/pull/21)
+- `cyberark/conjur-api-java@2.0.0`: Configuration change. When using environment variables, use CONJUR_AUTHN_LOGIN and CONJUR_AUTHN_API_KEY now instead of CONJUR_CREDENTIALS - [https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb](https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb)
 - `cyberark/conjur-oss-helm-chart@1.3.7`: Server ciphers have been upgraded to TLS1.2 levels.
 
 ### Fixed

--- a/pkg/cli/testdata/expected_docs-release_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_output.txt
@@ -17,6 +17,12 @@
       <li>
         <p><a href="https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5">cyberark/conjur-api-python3 v0.0.5</a> (2019-12-06)</p>
       </li>
+      <li>
+        <p><a href="https://github.com/cyberark/conjur-api-java/releases/tag/v2.0.0">cyberark/conjur-api-java v2.0.0</a> (2018-07-12)</p>
+      </li>
+      <li>
+        <p><a href="https://github.com/cyberark/conjur-api-go/releases/tag/v0.6.0">cyberark/conjur-api-go v0.6.0</a> (2019-03-04)</p>
+      </li>
     </ul>
 
     <h2>Upgrade Instructions</h2>
@@ -110,6 +116,34 @@ from the id.</p>
       <ul>
         <li>
           <p>Added ability to delete policies <a href="https://github.com/cyberark/conjur-api-python3/issues/23">#23</a></p>
+        </li>
+      </ul>
+    <h3 class="list">cyberark/conjur-api-java</h3>
+      <h4><a href="https://github.com/cyberark/conjur-api-java/releases/tag/v2.0.0">v2.0.0</a> (2018-07-12)</h4>
+      <p><strong>Added</strong></p>
+      <ul>
+        <li>
+          <p>License updated to Apache v2 - <a href="https://github.com/cyberark/conjur-api-java/pull/8">PR #8</a></p>
+        </li>
+      </ul>
+      <p><strong>Changed</strong></p>
+      <ul>
+        <li>
+          <p>Authn tokens now use the new Conjur 5 format - <a href="https://github.com/cyberark/conjur-api-java/pull/21">PR #21</a></p>
+        </li>
+        <li>
+          <p>Configuration change. When using environment variables, use CONJUR_AUTHN_LOGIN and CONJUR_AUTHN_API_KEY now instead of CONJUR_CREDENTIALS - <a href="https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb">https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb</a></p>
+        </li>
+      </ul>
+    <h3 class="list">cyberark/conjur-api-go</h3>
+      <h4><a href="https://github.com/cyberark/conjur-api-go/releases/tag/v0.6.0">v0.6.0</a> (2019-03-04)</h4>
+      <p><strong>Added</strong></p>
+      <ul>
+        <li>
+          <p>Converted to Golang 1.12</p>
+        </li>
+        <li>
+          <p>Started using os.UserHomeDir() built-in instead of go-homedir module</p>
         </li>
       </ul>
   </body>

--- a/pkg/cli/testdata/expected_release_diff_output.txt
+++ b/pkg/cli/testdata/expected_release_diff_output.txt
@@ -15,9 +15,9 @@ All notable changes to this project will be documented in this file.
 These are the components that combine to create this Conjur OSS Suite release and links
 to their releases:
 
-- **[cyberark/conjur v1.4.7](https://github.com/cyberark/conjur/releases/tag/v1.4.7)** (2020-03-12) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-Blue)](https://github.com/cyberark/conjur)
-- **[cyberark/conjur-oss-helm-chart v1.3.8](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8)** (2019-12-20) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-Green)](https://github.com/cyberark/conjur-oss-helm-chart)
-- **[cyberark/conjur-api-python3 v0.0.5](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5)** (2019-12-06) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Community-Yellow)](https://github.com/cyberark/conjur-api-python3)
+- **[cyberark/conjur v1.4.7](https://github.com/cyberark/conjur/releases/tag/v1.4.7)** (2020-03-12) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-007BFF)](https://github.com/cyberark/conjur)
+- **[cyberark/conjur-oss-helm-chart v1.3.8](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8)** (2019-12-20) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-6C757D)](https://github.com/cyberark/conjur-oss-helm-chart)
+- **[cyberark/conjur-api-python3 v0.0.5](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5)** (2019-12-06) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Community-28A745)](https://github.com/cyberark/conjur-api-python3)
 
 ## Installation Instructions for the Suite Release Version of Conjur
 

--- a/pkg/cli/testdata/expected_release_output.txt
+++ b/pkg/cli/testdata/expected_release_output.txt
@@ -15,9 +15,9 @@ All notable changes to this project will be documented in this file.
 These are the components that combine to create this Conjur OSS Suite release and links
 to their releases:
 
-- **[cyberark/conjur v1.4.6](https://github.com/cyberark/conjur/releases/tag/v1.4.6)** (2020-01-21) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-Blue)](https://github.com/cyberark/conjur)
-- **[cyberark/conjur-oss-helm-chart v1.3.7](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7)** (2019-01-31) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-Green)](https://github.com/cyberark/conjur-oss-helm-chart)
-- **[cyberark/conjur-api-python3 v0.0.5](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5)** (2019-12-06) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Community-Yellow)](https://github.com/cyberark/conjur-api-python3)
+- **[cyberark/conjur v1.4.6](https://github.com/cyberark/conjur/releases/tag/v1.4.6)** (2020-01-21) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-007BFF)](https://github.com/cyberark/conjur)
+- **[cyberark/conjur-oss-helm-chart v1.3.7](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7)** (2019-01-31) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-6C757D)](https://github.com/cyberark/conjur-oss-helm-chart)
+- **[cyberark/conjur-api-python3 v0.0.5](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5)** (2019-12-06) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Community-28A745)](https://github.com/cyberark/conjur-api-python3)
 
 ## Installation Instructions for the Suite Release Version of Conjur
 

--- a/pkg/cli/testdata/expected_release_output.txt
+++ b/pkg/cli/testdata/expected_release_output.txt
@@ -18,6 +18,8 @@ to their releases:
 - **[cyberark/conjur v1.4.6](https://github.com/cyberark/conjur/releases/tag/v1.4.6)** (2020-01-21) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-007BFF)](https://github.com/cyberark/conjur)
 - **[cyberark/conjur-oss-helm-chart v1.3.7](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7)** (2019-01-31) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-6C757D)](https://github.com/cyberark/conjur-oss-helm-chart)
 - **[cyberark/conjur-api-python3 v0.0.5](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5)** (2019-12-06) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Community-28A745)](https://github.com/cyberark/conjur-api-python3)
+- **[cyberark/conjur-api-java v2.0.0](https://github.com/cyberark/conjur-api-java/releases/tag/v2.0.0)** (2018-07-12) 
+- **[cyberark/conjur-api-go v0.6.0](https://github.com/cyberark/conjur-api-go/releases/tag/v0.6.0)** (2019-03-04) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Unknown-DC3545)](https://github.com/cyberark/conjur-api-go)
 
 ## Installation Instructions for the Suite Release Version of Conjur
 
@@ -61,6 +63,8 @@ OSS Suite release:
 - [cyberark/conjur](#cyberarkconjur)
 - [cyberark/conjur-oss-helm-chart](#cyberarkconjur-oss-helm-chart)
 - [cyberark/conjur-api-python3](#cyberarkconjur-api-python3)
+- [cyberark/conjur-api-java](#cyberarkconjur-api-java)
+- [cyberark/conjur-api-go](#cyberarkconjur-api-go)
 
 ### cyberark/conjur
 
@@ -99,3 +103,17 @@ from the id.
 #### [v0.0.5](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5) (2019-12-06)
 * **Added**
     - Added ability to delete policies [#23](https://github.com/cyberark/conjur-api-python3/issues/23)
+### cyberark/conjur-api-java
+
+#### [v2.0.0](https://github.com/cyberark/conjur-api-java/releases/tag/v2.0.0) (2018-07-12)
+* **Added**
+    - License updated to Apache v2 - [PR #8](https://github.com/cyberark/conjur-api-java/pull/8)
+* **Changed**
+    - Authn tokens now use the new Conjur 5 format - [PR #21](https://github.com/cyberark/conjur-api-java/pull/21)
+    - Configuration change. When using environment variables, use CONJUR_AUTHN_LOGIN and CONJUR_AUTHN_API_KEY now instead of CONJUR_CREDENTIALS - [https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb](https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb)
+### cyberark/conjur-api-go
+
+#### [v0.6.0](https://github.com/cyberark/conjur-api-go/releases/tag/v0.6.0) (2019-03-04)
+* **Added**
+    - Converted to Golang 1.12
+    - Started using os.UserHomeDir() built-in instead of go-homedir module

--- a/pkg/cli/testdata/suite.yml
+++ b/pkg/cli/testdata/suite.yml
@@ -27,3 +27,12 @@ section:
         description: Conjur Python Client Library
         version: v0.0.5
         certification: "community"
+      - name: cyberark/conjur-api-java
+        url: https://github.com/cyberark/conjur-api-java
+        description: Conjur Java Client Library
+        version: v2.0.0
+      - name: cyberark/conjur-api-go
+        url: https://github.com/cyberark/conjur-api-go
+        description: Conjur Golang Client Library
+        version: v0.6.0
+        certification: "unknown"

--- a/releases/suite_0.0.0.yml
+++ b/releases/suite_0.0.0.yml
@@ -10,19 +10,12 @@ section:
         url: https://github.com/cyberark/conjur
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
-        certification: "certified"
         version: v1.4.4
         upgrade_url: https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
         version: v1.3.7
-        certification: "trusted"
-#      - name: cyberark/conjur-aws
-#        url: https://github.com/cyberark/conjur-aws
-#        description: AWS CloudFormation templates for deploying Conjur OSS.
-#        certification: "community"
-#        version: nil # No tags, can't include in release
 
   - name: Conjur SDK
     description: Conjur Command Line Interface (CLI) and Client Libraries
@@ -30,32 +23,26 @@ section:
       - name: cyberark/conjur-cli
         url: https://github.com/cyberark/conjur-cli
         description: Conjur Ruby CLI
-        certification: "certified"
         version: v6.0.1
       - name: cyberark/conjur-api-dotnet
         url: https://github.com/cyberark/conjur-api-dotnet
         description: Conjur .Net Client Library
-        certification: "community"
         version: v1.4.0
       - name: cyberark/conjur-api-go
         url: https://github.com/cyberark/conjur-api-go
         description: Conjur Golang Client Library
-        certification: "certified"
         version: v0.5.2
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
-        certification: "community"
         version: v2.0.0
       - name: cyberark/conjur-api-python3
         url: https://github.com/cyberark/conjur-api-python3
         description: Conjur Python Client Library
-        certification: "community"
         version: v0.0.5
       - name: cyberark/conjur-api-ruby
         url: https://github.com/cyberark/conjur-api-ruby
         description: Conjur Ruby Client Library
-        certification: "certified"
         version: v5.3.1
 
   # This section goes back two versions to help ensure our logic for computing
@@ -70,7 +57,6 @@ section:
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        certification: "certified"
         version: v0.15.0
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
@@ -78,14 +64,12 @@ section:
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        certification: "certified"
         version: v0.2.0
       - name: cyberark/conjur-service-broker
         url: https://github.com/cyberark/conjur-service-broker
         tool: Cloud Foundry
         description: The Conjur service broker ensures your Cloud Foundry-deployed
           applications are bootstrapped with a Conjur machine identity on deploy.
-        certification: "certified"
         version: v1.0.0
       - name: cyberark/cloudfoundry-conjur-buildpack
         url: https://github.com/cyberark/cloudfoundry-conjur-buildpack
@@ -94,7 +78,6 @@ section:
           your Cloud Foundry-deployed applications. Leverage your app's Conjur identity
           to automatically inject the secrets your app needs into its environment
           at runtime.
-        certification: "certified"
         version: v2.1.1
 
   - name: DevOps Tools
@@ -106,13 +89,11 @@ section:
         description: Ansible role to provide Conjur machine identity to application
           hosts and install the Summon tool, which enables hosts to securely retrieve
           credentials.
-        certification: "trusted"
         version: v0.3.1
       - name: cyberark/conjur-credentials-plugin
         url: https://github.com/cyberark/conjur-credentials-plugin
         tool: Jenkins
         description: Conjur plugin for securely providing credentials to Jenkins jobs.
-        certification: "community"
         version: v0.7.0
       - name: cyberark/conjur-puppet
         url: https://github.com/cyberark/conjur-puppet
@@ -120,14 +101,12 @@ section:
         description: Puppet module that simplifies the operation of establishing
           Conjur host identity and allows authorized Puppet nodes to fetch secrets
           from Conjur.
-        certification: "trusted"
         version: v2.0.1
       - name: cyberark/terraform-provider-conjur
         url: https://github.com/cyberark/terraform-provider-conjur
         tool: Terraform
         description: Terraform provider that makes secrets in Conjur available in
           Terraform manifests.
-        certification: "certified"
         version: v0.1.0
 
   - name: Secretless Broker
@@ -138,7 +117,6 @@ section:
         description: Secretless Broker can be used to securely connect your
           applications to services they need - without ever having to fetch or
           manage passwords and keys.
-        certification: "certified"
         version: v1.5.1
 
   - name: Summon
@@ -149,30 +127,24 @@ section:
         url: https://github.com/cyberark/summon
         description: Summon is a secure tool to inject secrets into a subprocess
           environment.
-        certification: "certified"
         version: v0.8.0
       - name: cyberark/summon-aws-secrets
         url: https://github.com/cyberark/summon-aws-secrets
         description: Summon provider for AWS Secrets Manager.
-        certification: "community"
         version: v0.2.0
       - name: cyberark/summon-chefapi
         url: https://github.com/cyberark/summon-chefapi
         description: Summon provider for Chef encrypted data bags.
-        certification: "community"
         version: v0.1.0
       - name: cyberark/summon-conjur
         url: https://github.com/cyberark/summon-conjur
         description: Summon provider for Conjur.
-        certification: "certified"
         version: v0.5.2
       - name: cyberark/summon-keyring
         url: https://github.com/cyberark/summon-keyring
         description: Summon provider for cross-platform keyrings.
-        certification: "community"
         version: v0.2.1
       - name: cyberark/summon-s3
         url: https://github.com/cyberark/summon-s3
         description: Summon provider for AWS S3.
-        certification: "community"
         version: v0.1.0

--- a/suite.yml
+++ b/suite.yml
@@ -10,25 +10,17 @@ section:
         url: https://github.com/cyberark/conjur
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
-        certification: "certified"
         version: v1.4.4
         upgrade_url: https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
         version: v1.3.8
-        certification: "trusted"
       - name: cyberark/conjur-google-cloud-marketplace
         url: https://github.com/cyberark/conjur-google-cloud-marketplace
         description: Google Cloud Marketplace integration for deploying Conjur OSS.
         version: v1.2.0
-        certification: "trusted"
         upgrade_url: https://github.com/cyberark/conjur-google-cloud-marketplace/#upgrade-the-application
-#      - name: cyberark/conjur-aws
-#        url: https://github.com/cyberark/conjur-aws
-#        description: AWS CloudFormation templates for deploying Conjur OSS.
-#        certification: "community"
-#        version: nil # No tags, can't include in release
 
   - name: Conjur SDK
     description: Conjur Command Line Interface (CLI) and Client Libraries
@@ -36,32 +28,26 @@ section:
       - name: cyberark/conjur-cli
         url: https://github.com/cyberark/conjur-cli
         description: Conjur Ruby CLI
-        certification: "certified"
         version: v6.0.1
       - name: cyberark/conjur-api-dotnet
         url: https://github.com/cyberark/conjur-api-dotnet
         description: Conjur .Net Client Library
-        certification: "community"
         version: v1.4.0
       - name: cyberark/conjur-api-go
         url: https://github.com/cyberark/conjur-api-go
         description: Conjur Golang Client Library
-        certification: "certified"
         version: v0.5.2
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
-        certification: "community"
         version: v2.0.0
       - name: cyberark/conjur-api-python3
         url: https://github.com/cyberark/conjur-api-python3
         description: Conjur Python Client Library
-        certification: "community"
         version: v0.0.5
       - name: cyberark/conjur-api-ruby
         url: https://github.com/cyberark/conjur-api-ruby
         description: Conjur Ruby Client Library
-        certification: "certified"
         version: v5.3.1
 
   # This section goes back two versions to help ensure our logic for computing
@@ -76,7 +62,6 @@ section:
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        certification: "certified"
         version: v0.15.0
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
@@ -84,14 +69,12 @@ section:
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        certification: "certified"
         version: v0.2.0
       - name: cyberark/conjur-service-broker
         url: https://github.com/cyberark/conjur-service-broker
         tool: Cloud Foundry
         description: The Conjur service broker ensures your Cloud Foundry-deployed
           applications are bootstrapped with a Conjur machine identity on deploy.
-        certification: "certified"
         version: v1.0.0
       - name: cyberark/cloudfoundry-conjur-buildpack
         url: https://github.com/cyberark/cloudfoundry-conjur-buildpack
@@ -100,7 +83,6 @@ section:
           your Cloud Foundry-deployed applications. Leverage your app's Conjur identity
           to automatically inject the secrets your app needs into its environment
           at runtime.
-        certification: "certified"
         version: v2.1.1
 
   - name: DevOps Tools
@@ -112,13 +94,11 @@ section:
         description: Ansible role to provide Conjur machine identity to application
           hosts and install the Summon tool, which enables hosts to securely retrieve
           credentials.
-        certification: "trusted"
         version: v0.3.1
       - name: cyberark/conjur-credentials-plugin
         url: https://github.com/cyberark/conjur-credentials-plugin
         tool: Jenkins
         description: Conjur plugin for securely providing credentials to Jenkins jobs.
-        certification: "community"
         version: v0.7.0
       - name: cyberark/conjur-puppet
         url: https://github.com/cyberark/conjur-puppet
@@ -126,14 +106,12 @@ section:
         description: Puppet module that simplifies the operation of establishing
           Conjur host identity and allows authorized Puppet nodes to fetch secrets
           from Conjur.
-        certification: "trusted"
         version: v2.0.1
       - name: cyberark/terraform-provider-conjur
         url: https://github.com/cyberark/terraform-provider-conjur
         tool: Terraform
         description: Terraform provider that makes secrets in Conjur available in
           Terraform manifests.
-        certification: "certified"
         version: v0.1.0
 
   - name: Secretless Broker
@@ -144,7 +122,6 @@ section:
         description: Secretless Broker can be used to securely connect your
           applications to services they need - without ever having to fetch or
           manage passwords and keys.
-        certification: "certified"
         version: v1.5.1
 
   - name: Summon
@@ -155,30 +132,24 @@ section:
         url: https://github.com/cyberark/summon
         description: Summon is a secure tool to inject secrets into a subprocess
           environment.
-        certification: "certified"
         version: v0.8.0
       - name: cyberark/summon-aws-secrets
         url: https://github.com/cyberark/summon-aws-secrets
         description: Summon provider for AWS Secrets Manager.
-        certification: "community"
         version: v0.2.0
       - name: cyberark/summon-chefapi
         url: https://github.com/cyberark/summon-chefapi
         description: Summon provider for Chef encrypted data bags.
-        certification: "community"
         version: v0.1.0
       - name: cyberark/summon-conjur
         url: https://github.com/cyberark/summon-conjur
         description: Summon provider for Conjur.
-        certification: "certified"
         version: v0.5.2
       - name: cyberark/summon-keyring
         url: https://github.com/cyberark/summon-keyring
         description: Summon provider for cross-platform keyrings.
-        certification: "community"
         version: v0.2.1
       - name: cyberark/summon-s3
         url: https://github.com/cyberark/summon-s3
         description: Summon provider for AWS S3.
-        certification: "community"
         version: v0.1.0

--- a/suite.yml
+++ b/suite.yml
@@ -10,7 +10,7 @@ section:
         url: https://github.com/cyberark/conjur
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
-        version: v1.4.4
+        version: v1.5.0
         upgrade_url: https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
@@ -28,7 +28,7 @@ section:
       - name: cyberark/conjur-cli
         url: https://github.com/cyberark/conjur-cli
         description: Conjur Ruby CLI
-        version: v6.0.1
+        version: v6.2.2
       - name: cyberark/conjur-api-dotnet
         url: https://github.com/cyberark/conjur-api-dotnet
         description: Conjur .Net Client Library
@@ -36,7 +36,7 @@ section:
       - name: cyberark/conjur-api-go
         url: https://github.com/cyberark/conjur-api-go
         description: Conjur Golang Client Library
-        version: v0.5.2
+        version: v0.6.0
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
@@ -62,20 +62,20 @@ section:
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        version: v0.15.0
+        version: v0.16.1
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
         tool: Kubernetes
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        version: v0.2.0
+        version: v0.4.0
       - name: cyberark/conjur-service-broker
         url: https://github.com/cyberark/conjur-service-broker
         tool: Cloud Foundry
         description: The Conjur service broker ensures your Cloud Foundry-deployed
           applications are bootstrapped with a Conjur machine identity on deploy.
-        version: v1.0.0
+        version: v1.1.1
       - name: cyberark/cloudfoundry-conjur-buildpack
         url: https://github.com/cyberark/cloudfoundry-conjur-buildpack
         tool: Cloud Foundry
@@ -83,7 +83,7 @@ section:
           your Cloud Foundry-deployed applications. Leverage your app's Conjur identity
           to automatically inject the secrets your app needs into its environment
           at runtime.
-        version: v2.1.1
+        version: v2.1.3
 
   - name: DevOps Tools
     description: Conjur OSS integrations with DevOps tools.
@@ -99,20 +99,20 @@ section:
         url: https://github.com/cyberark/conjur-credentials-plugin
         tool: Jenkins
         description: Conjur plugin for securely providing credentials to Jenkins jobs.
-        version: v0.7.0
+        version: v0.8.0
       - name: cyberark/conjur-puppet
         url: https://github.com/cyberark/conjur-puppet
         tool: Puppet
         description: Puppet module that simplifies the operation of establishing
           Conjur host identity and allows authorized Puppet nodes to fetch secrets
           from Conjur.
-        version: v2.0.1
+        version: v2.0.2
       - name: cyberark/terraform-provider-conjur
         url: https://github.com/cyberark/terraform-provider-conjur
         tool: Terraform
         description: Terraform provider that makes secrets in Conjur available in
           Terraform manifests.
-        version: v0.1.0
+        version: v0.3.0
 
   - name: Secretless Broker
     description: Secure your apps by making them Secretless.
@@ -122,7 +122,7 @@ section:
         description: Secretless Broker can be used to securely connect your
           applications to services they need - without ever having to fetch or
           manage passwords and keys.
-        version: v1.5.1
+        version: v1.5.2
 
   - name: Summon
     description: Run your processes wrapped with Summon to ensure they have
@@ -132,19 +132,19 @@ section:
         url: https://github.com/cyberark/summon
         description: Summon is a secure tool to inject secrets into a subprocess
           environment.
-        version: v0.8.0
+        version: v0.8.1
       - name: cyberark/summon-aws-secrets
         url: https://github.com/cyberark/summon-aws-secrets
         description: Summon provider for AWS Secrets Manager.
-        version: v0.2.0
+        version: v0.3.0
       - name: cyberark/summon-chefapi
         url: https://github.com/cyberark/summon-chefapi
         description: Summon provider for Chef encrypted data bags.
-        version: v0.1.0
+        version: v0.1.1
       - name: cyberark/summon-conjur
         url: https://github.com/cyberark/summon-conjur
         description: Summon provider for Conjur.
-        version: v0.5.2
+        version: v0.5.3
       - name: cyberark/summon-keyring
         url: https://github.com/cyberark/summon-keyring
         description: Summon provider for cross-platform keyrings.
@@ -152,4 +152,4 @@ section:
       - name: cyberark/summon-s3
         url: https://github.com/cyberark/summon-s3
         description: Summon provider for AWS S3.
-        version: v0.1.0
+        version: v0.2.0

--- a/templates/RELEASE_NOTES_unified.md.tmpl
+++ b/templates/RELEASE_NOTES_unified.md.tmpl
@@ -50,4 +50,4 @@ OSS Suite release:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- end -}}
+{{- end }}

--- a/templates/partials/certification_badge.md
+++ b/templates/partials/certification_badge.md
@@ -1,9 +1,9 @@
 {{- if eq (toLower .CertificationLevel) "trusted" -}}
-[![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-Blue)]({{ .URL }})
+[![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-007BFF)]({{ .URL }})
 {{- else if eq (toLower .CertificationLevel) "certified" -}}
-[![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-Green)]({{ .URL }})
+[![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-6C757D)]({{ .URL }})
 {{- else if eq (toLower .CertificationLevel) "community" -}}
-[![Certification Level](https://img.shields.io/badge/Certification%20Level-Community-Yellow)]({{ .URL }})
+[![Certification Level](https://img.shields.io/badge/Certification%20Level-Community-28A745)]({{ .URL }})
 {{- else -}}
-[![Certification Level](https://img.shields.io/badge/Certification%20Level-Unknown-Red)]({{ .URL }})
+[![Certification Level](https://img.shields.io/badge/Certification%20Level-Unknown-DC3545)]({{ .URL }})
 {{- end -}}

--- a/templates/partials/certification_badge.md
+++ b/templates/partials/certification_badge.md
@@ -4,6 +4,6 @@
 [![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-6C757D)]({{ .URL }})
 {{- else if eq (toLower .CertificationLevel) "community" -}}
 [![Certification Level](https://img.shields.io/badge/Certification%20Level-Community-28A745)]({{ .URL }})
-{{- else -}}
+{{- else if eq (toLower .CertificationLevel) "unknown" -}}
 [![Certification Level](https://img.shields.io/badge/Certification%20Level-Unknown-DC3545)]({{ .URL }})
 {{- end -}}

--- a/templates/partials/testdata/certification_badge_certified.md
+++ b/templates/partials/testdata/certification_badge_certified.md
@@ -1,1 +1,1 @@
-[![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-Green)](http://repo-url)
+[![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-6C757D)](http://repo-url)

--- a/templates/partials/testdata/certification_badge_community.md
+++ b/templates/partials/testdata/certification_badge_community.md
@@ -1,1 +1,1 @@
-[![Certification Level](https://img.shields.io/badge/Certification%20Level-Community-Yellow)](http://repo-url)
+[![Certification Level](https://img.shields.io/badge/Certification%20Level-Community-28A745)](http://repo-url)

--- a/templates/partials/testdata/certification_badge_trusted.md
+++ b/templates/partials/testdata/certification_badge_trusted.md
@@ -1,1 +1,1 @@
-[![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-Blue)](http://repo-url)
+[![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-007BFF)](http://repo-url)

--- a/templates/partials/testdata/certification_badge_unknown.md
+++ b/templates/partials/testdata/certification_badge_unknown.md
@@ -1,1 +1,1 @@
-[![Certification Level](https://img.shields.io/badge/Certification%20Level-Unknown-Red)](http://repo-url)
+[![Certification Level](https://img.shields.io/badge/Certification%20Level-Unknown-DC3545)](http://repo-url)

--- a/templates/testdata/RELEASE_NOTES_unified.md
+++ b/templates/testdata/RELEASE_NOTES_unified.md
@@ -15,8 +15,8 @@ All notable changes to this project will be documented in this file.
 These are the components that combine to create this Conjur OSS Suite release and links
 to their releases:
 
-- **[cyberark/conjur v1.4.4](https://github.com/cyberark/conjur/releases/tag/v1.4.4)** (2020-01-03) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-Blue)](https://github.com/cyberark/conjur)
-- **[cyberark/secretless-broker v1.4.2](https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2)** (2020-01-08) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-Green)](https://github.com/cyberark/secretless-broker)
+- **[cyberark/conjur v1.4.4](https://github.com/cyberark/conjur/releases/tag/v1.4.4)** (2020-01-03) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-007BFF)](https://github.com/cyberark/conjur)
+- **[cyberark/secretless-broker v1.4.2](https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2)** (2020-01-08) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-6C757D)](https://github.com/cyberark/secretless-broker)
 
 ## Installation Instructions for the Suite Release Version of Conjur
 


### PR DESCRIPTION
- Clean up the dev 0.0.0 release in preparation for tagging an actual baseline 0.0.1 release
- Bump the versions in the suite.yml to be consistent with where projects were as of the DAP 11.4 RC build on April 2
- Edit the default certification level colors to the values we plan to use, and update the code to not print CL info if the level is unknown