### PR TITLE
Update postgresql helm chart to pull from bitnami repository

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           version: v3.1.2
 
-      - name: Add Helm 'stable' repository
-        run: helm repo add stable https://kubernetes-charts.storage.googleapis.com/ && helm repo update
+      - name: Add Helm 'bitnami' repository
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami && helm repo update
 
       - name: Run releases test
         working-directory: ./release-testing

--- a/k8s-ci/Dockerfile
+++ b/k8s-ci/Dockerfile
@@ -30,6 +30,6 @@ RUN HELM_VERSION=v3.0.2 && \
     rm helm-${HELM_VERSION}-linux-amd64.tar.gz && \
     rm -rf linux-amd64
 
-# Install Helm stable repo
-RUN helm repo add stable https://kubernetes-charts.storage.googleapis.com/ && \
+# Install Helm bitnami repo
+RUN helm repo add bitnami https://charts.bitnami.com/bitnami && \
     helm repo update

--- a/release-testing/prepare.sh
+++ b/release-testing/prepare.sh
@@ -13,7 +13,7 @@ function deploy_pg {
   helm install --namespace "${TEST_NAMESPACE}" "${PG_RELEASE_NAME}" \
     --set postgresqlPassword="${DB_PASSWORD}" \
     --set persistence.enabled="false" \
-    stable/postgresql
+    bitnami/postgresql
 }
 
 function deploy_conjur {


### PR DESCRIPTION
The postgresql helm chart has been depracted from the stable repository and moved to the bitnami repository. This commit makes the relevant changes.