### PR TITLE
Updating suite.yml for 1.5.0+suite.1 release

### DIFF
--- a/suite.yml
+++ b/suite.yml
@@ -34,7 +34,7 @@ section:
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
-        version: v2.2.0
+        version: v2.2.1
       - name: cyberark/conjur-api-python3
         url: https://github.com/cyberark/conjur-api-python3
         description: Conjur Python Client Library

--- a/suite.yml
+++ b/suite.yml
@@ -11,16 +11,10 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         version: v1.5.0
-        upgrade_url: https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
         version: v1.3.8
-      - name: cyberark/conjur-google-cloud-marketplace
-        url: https://github.com/cyberark/conjur-google-cloud-marketplace
-        description: Google Cloud Marketplace integration for deploying Conjur OSS.
-        version: v1.2.0
-        upgrade_url: https://github.com/cyberark/conjur-google-cloud-marketplace/#upgrade-the-application
 
   - name: Conjur SDK
     description: Conjur Command Line Interface (CLI) and Client Libraries
@@ -40,7 +34,7 @@ section:
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
-        version: v2.0.0
+        version: v2.2.0
       - name: cyberark/conjur-api-python3
         url: https://github.com/cyberark/conjur-api-python3
         description: Conjur Python Client Library
@@ -58,7 +52,7 @@ section:
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        version: v0.16.1
+        version: v0.18.0
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
         tool: Kubernetes
@@ -91,11 +85,6 @@ section:
           hosts and install the Summon tool, which enables hosts to securely retrieve
           credentials.
         version: v0.3.1
-      - name: cyberark/conjur-credentials-plugin
-        url: https://github.com/cyberark/conjur-credentials-plugin
-        tool: Jenkins
-        description: Conjur plugin for securely providing credentials to Jenkins jobs.
-        version: v0.8.0
       - name: cyberark/conjur-puppet
         url: https://github.com/cyberark/conjur-puppet
         tool: Puppet
@@ -108,7 +97,7 @@ section:
         tool: Terraform
         description: Terraform provider that makes secrets in Conjur available in
           Terraform manifests.
-        version: v0.3.0
+        version: v0.4.0
 
   - name: Secretless Broker
     description: Secure your apps by making them Secretless.


### PR DESCRIPTION
Repos with changes on master that we are not including in this version, since both require a fair amount of manual testing before we can tag, and we don't want to block the release:
- Summon
- Python3

I also removed Google cloud marketplace from this initial suite release - the project isn't ready yet with a published version that uses the suite Conjur version, so rather than have it block the release, we have removed it for now.