### PR TITLE
Updates for 1.5.0+suite.1 release

### DIFF
--- a/suite.yml
+++ b/suite.yml
@@ -11,10 +11,6 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         version: v1.5.0
-      - name: cyberark/conjur-oss-helm-chart
-        url: https://github.com/cyberark/conjur-oss-helm-chart
-        description: Helm chart for deploying Conjur OSS.
-        version: v1.3.8
 
   - name: Conjur SDK
     description: Conjur Command Line Interface (CLI) and Client Libraries
@@ -23,10 +19,6 @@ section:
         url: https://github.com/cyberark/conjur-cli
         description: Conjur Ruby CLI
         version: v6.2.2
-      - name: cyberark/conjur-api-dotnet
-        url: https://github.com/cyberark/conjur-api-dotnet
-        description: Conjur .Net Client Library
-        version: v1.4.0
       - name: cyberark/conjur-api-go
         url: https://github.com/cyberark/conjur-api-go
         description: Conjur Golang Client Library
@@ -65,7 +57,7 @@ section:
         tool: Cloud Foundry
         description: The Conjur service broker ensures your Cloud Foundry-deployed
           applications are bootstrapped with a Conjur machine identity on deploy.
-        version: v1.1.1
+        version: v1.1.2
       - name: cyberark/cloudfoundry-conjur-buildpack
         url: https://github.com/cyberark/cloudfoundry-conjur-buildpack
         tool: Cloud Foundry


### PR DESCRIPTION
Connected to https://github.com/cyberark/conjur-oss-suite-release/issues/167

- Removes .net API for now
- Removes helm chart for now
- Bumps the service broker to the new 1.1.2 version, which cleans up the release output