### PR TITLE
Fixed clipping of unbounded upper releases version numbers

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -214,11 +214,6 @@ func componentFromRepo(
 		return component, err
 	}
 
-	if repo.Version == "" {
-		log.OutLogger.Printf("  Repo 'latest' release resolved as '%s'", highestVersion)
-		repo.Version = highestVersion
-	}
-
 	// Get a comparison between the highest version and HEAD
 	comparison, err := compareRefs(httpClient, repo.Name, highestVersion, "HEAD")
 	if err != nil {


### PR DESCRIPTION
Old code would assume that a missing upper or lower bound should be
treated the same but effectively they have different meanings:
- Missing lower bound should just return current high bound
- Missing upper bound should be used like a normal comparison baseline
  which may not return a result

This change should fix the resulting output of unreleased changes while
having no effect on other outputs.

Connected to #154