### PR TITLE
169 Add install instructions to html docs

### DIFF
--- a/pkg/cli/testdata/expected_docs-release_diff_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_diff_output.txt
@@ -23,6 +23,40 @@
       </li>
     </ul>
 
+    <!--
+      This section should be in a partial on its own but we can't do that until issue
+      https://github.com/cyberark/conjur-oss-helm-chart/issues/50 is done
+    -->
+    <h2>Installation Instructions for the Suite Release Version of Conjur</h2>
+    Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.
+
+    <ul>
+      <li>
+        <b>Docker or docker-compose</b>
+
+        <p>
+        Set the container image tag to <code>cyberark/conjur:1.4.7</code>. For
+        example, make the following update to the conjur service in the
+        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml">quickstart docker-compose.yml</a>:
+        </p>
+
+        <pre><code>image: cyberark/conjur:1.4.7</code></pre>
+      </li>
+      <li>
+        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart">Conjur OSS Helm chart</a></b>
+
+        <p>
+        Update the <code>image.tag</code> value and use the appropriate release of the helm
+        chart:
+        </p>
+
+        <pre><code>helm install ... \
+  --set image.tag="1.4.7" \
+  ...
+  https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v1.3.8/conjur-oss-1.3.8.tgz</code></pre>
+      </li>
+    </ul>
+
     <h2>Upgrade Instructions</h2>
     <p>Upgrade instructions are available for the following suite components:</p>
     <ul>

--- a/pkg/cli/testdata/expected_docs-release_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_output.txt
@@ -29,6 +29,40 @@
       </li>
     </ul>
 
+    <!--
+      This section should be in a partial on its own but we can't do that until issue
+      https://github.com/cyberark/conjur-oss-helm-chart/issues/50 is done
+    -->
+    <h2>Installation Instructions for the Suite Release Version of Conjur</h2>
+    Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.
+
+    <ul>
+      <li>
+        <b>Docker or docker-compose</b>
+
+        <p>
+        Set the container image tag to <code>cyberark/conjur:1.4.6</code>. For
+        example, make the following update to the conjur service in the
+        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml">quickstart docker-compose.yml</a>:
+        </p>
+
+        <pre><code>image: cyberark/conjur:1.4.6</code></pre>
+      </li>
+      <li>
+        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart">Conjur OSS Helm chart</a></b>
+
+        <p>
+        Update the <code>image.tag</code> value and use the appropriate release of the helm
+        chart:
+        </p>
+
+        <pre><code>helm install ... \
+  --set image.tag="1.4.6" \
+  ...
+  https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v1.3.7/conjur-oss-1.3.7.tgz</code></pre>
+      </li>
+    </ul>
+
     <h2>Upgrade Instructions</h2>
     <p>Upgrade instructions are available for the following suite components:</p>
     <ul>

--- a/pkg/cli/testdata/expected_release_diff_output.txt
+++ b/pkg/cli/testdata/expected_release_diff_output.txt
@@ -34,14 +34,6 @@ Installing the Suite Release Version of Conjur requires setting the container im
   image: cyberark/conjur:1.4.7
   ```
 
-+ [**Cloud Formation templates for AWS**](https://github.com/cyberark/conjur-aws)
-
-  Set the environment variable CONJUR_VERSION before building the AMI:
-  ```
-  export CONJUR_VERSION="1.4.7"
-  ./build-ami.sh
-  ```
-
 + [**Conjur OSS Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)
 
   Update the `image.tag` value and use the appropriate release of the helm chart:

--- a/pkg/cli/testdata/expected_release_output.txt
+++ b/pkg/cli/testdata/expected_release_output.txt
@@ -36,14 +36,6 @@ Installing the Suite Release Version of Conjur requires setting the container im
   image: cyberark/conjur:1.4.6
   ```
 
-+ [**Cloud Formation templates for AWS**](https://github.com/cyberark/conjur-aws)
-
-  Set the environment variable CONJUR_VERSION before building the AMI:
-  ```
-  export CONJUR_VERSION="1.4.6"
-  ./build-ami.sh
-  ```
-
 + [**Conjur OSS Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)
 
   Update the `image.tag` value and use the appropriate release of the helm chart:

--- a/templates/RELEASE_NOTES_unified.htm.tmpl
+++ b/templates/RELEASE_NOTES_unified.htm.tmpl
@@ -1,3 +1,6 @@
+{{ $conjurVersion := .ComponentReleaseVersion "cyberark/conjur" -}}
+{{ $helmChartVersion := .ComponentReleaseVersion "cyberark/conjur-oss-helm-chart" -}}
+
 <?xml version="1.0" encoding="utf-8"?>
 <html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
   <head></head>
@@ -17,6 +20,43 @@
       {{- end }}
     </ul>
     {{- end }}
+
+    <!--
+      This section should be in a partial on its own but we can't do that until issue
+      https://github.com/cyberark/conjur-oss-helm-chart/issues/50 is done
+    -->
+    <h2>Installation Instructions for the Suite Release Version of Conjur</h2>
+    Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.
+
+    <ul>
+      <li>
+        <b>Docker or docker-compose</b>
+
+        <p>
+        Set the container image tag to <code>cyberark/conjur:{{$conjurVersion}}</code>. For
+        example, make the following update to the conjur service in the
+        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml">quickstart docker-compose.yml</a>:
+        </p>
+
+        <pre><code>image: cyberark/conjur:{{$conjurVersion}}</code></pre>
+      </li>
+
+{{- if $helmChartVersion }}
+      <li>
+        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart">Conjur OSS Helm chart</a></b>
+
+        <p>
+        Update the <code>image.tag</code> value and use the appropriate release of the helm
+        chart:
+        </p>
+
+        <pre><code>helm install ... \
+  --set image.tag="{{$conjurVersion}}" \
+  ...
+  https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v{{$helmChartVersion}}/conjur-oss-{{$helmChartVersion}}.tgz</code></pre>
+      </li>
+{{- end }}
+    </ul>
 
     <h2>Upgrade Instructions</h2>
     <p>Upgrade instructions are available for the following suite components:</p>

--- a/templates/partials/conjur_installation_instructions.md
+++ b/templates/partials/conjur_installation_instructions.md
@@ -9,14 +9,6 @@ Installing the Suite Release Version of Conjur requires setting the container im
   ```
   image: cyberark/conjur:{{$conjurVersion}}
   ```
-
-+ [**Cloud Formation templates for AWS**](https://github.com/cyberark/conjur-aws)
-
-  Set the environment variable CONJUR_VERSION before building the AMI:
-  ```
-  export CONJUR_VERSION="{{$conjurVersion}}"
-  ./build-ami.sh
-  ```
 {{- if $helmChartVersion }}
 
 + [**Conjur OSS Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -48,9 +48,10 @@ func TestTemplates(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	outputDate, _ := time.Parse(time.RFC3339, "2020-02-19T11:58:05Z")
-	date1, _ := time.Parse(time.RFC3339, "2020-02-01T11:58:05Z")
-	date2, _ := time.Parse(time.RFC3339, "2020-01-03T11:58:05Z")
-	date3, _ := time.Parse(time.RFC3339, "2020-01-08T11:58:05Z")
+	conjurReleaseDate1, _ := time.Parse(time.RFC3339, "2020-02-01T11:58:05Z")
+	conjurReleaseDate2, _ := time.Parse(time.RFC3339, "2020-01-03T11:58:05Z")
+	helmReleaseDate, _ := time.Parse(time.RFC3339, "2020-05-03T11:58:05Z")
+	secretlessReleaseDate, _ := time.Parse(time.RFC3339, "2020-01-08T11:58:05Z")
 
 	testData := template.ReleaseSuite{
 		Version:          "11.22.33",
@@ -65,7 +66,7 @@ func TestTemplates(t *testing.T) {
 						URL:                  "https://github.com/cyberark/conjur",
 						UnreleasedChangesURL: "https://github.com/cyberark/conjur/compare/v1.4.4...HEAD",
 						ReleaseName:          "v1.4.4",
-						ReleaseDate:          date2.Format("2006-01-02"),
+						ReleaseDate:          conjurReleaseDate2.Format("2006-01-02"),
 						CertificationLevel:   "trusted",
 						UpgradeURL:           "https://conjur_upgrade_url",
 						Changelogs: []*changelog.VersionChangelog{
@@ -73,7 +74,7 @@ func TestTemplates(t *testing.T) {
 								Repo:    "cyberark/conjur",
 								Version: "1.3.6",
 								// Why are these strings?
-								Date: date1.Format("2006-01-02"),
+								Date: conjurReleaseDate1.Format("2006-01-02"),
 								Sections: map[string][]string{
 									"Changed": []string{"136Change", "136Change2"},
 									"Removed": []string{"136Removal"},
@@ -83,7 +84,7 @@ func TestTemplates(t *testing.T) {
 								Repo:    "cyberark/conjur",
 								Version: "1.4.4",
 								// Why are these strings?
-								Date: date2.Format("2006-01-02"),
+								Date: conjurReleaseDate2.Format("2006-01-02"),
 								Sections: map[string][]string{
 									"Added":   []string{"144Addition", "144Addition2"},
 									"Changed": []string{"144Change", "144Change2"},
@@ -91,6 +92,15 @@ func TestTemplates(t *testing.T) {
 								},
 							},
 						},
+					},
+					github.SuiteComponent{
+						Repo:                 "cyberark/conjur-oss-helm-chart",
+						URL:                  "https://github.com/cyberark/conjur-oss-helm-chart",
+						UnreleasedChangesURL: "https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.3.8...HEAD",
+						ReleaseName:          "v1.3.8",
+						ReleaseDate:          helmReleaseDate.Format("2006-01-02"),
+						CertificationLevel:   "trusted",
+						Changelogs:           []*changelog.VersionChangelog{},
 					},
 				},
 			},
@@ -101,13 +111,13 @@ func TestTemplates(t *testing.T) {
 						Repo:               "cyberark/secretless-broker",
 						URL:                "https://github.com/cyberark/secretless-broker",
 						ReleaseName:        "v1.4.2",
-						ReleaseDate:        date3.Format("2006-01-02"),
+						ReleaseDate:        secretlessReleaseDate.Format("2006-01-02"),
 						CertificationLevel: "certified",
 						Changelogs: []*changelog.VersionChangelog{
 							&changelog.VersionChangelog{
 								Repo:    "cyberark/secretless-broker",
 								Version: "1.4.2",
-								Date:    date3.Format("2006-01-02"),
+								Date:    secretlessReleaseDate.Format("2006-01-02"),
 								Sections: map[string][]string{
 									"Added":   []string{"Broker142Addition"},
 									"Changed": []string{"Broker142Change"},

--- a/templates/testdata/RELEASE_NOTES_unified.htm
+++ b/templates/testdata/RELEASE_NOTES_unified.htm
@@ -12,11 +12,48 @@
       <li>
         <p><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.4">cyberark/conjur v1.4.4</a> (2020-01-03)</p>
       </li>
+      <li>
+        <p><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8">cyberark/conjur-oss-helm-chart v1.3.8</a> (2020-05-03)</p>
+      </li>
     </ul>
     <h3>Secrets Delivery</h3>
     <ul>
       <li>
         <p><a href="https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2">cyberark/secretless-broker v1.4.2</a> (2020-01-08)</p>
+      </li>
+    </ul>
+
+    <!--
+      This section should be in a partial on its own but we can't do that until issue
+      https://github.com/cyberark/conjur-oss-helm-chart/issues/50 is done
+    -->
+    <h2>Installation Instructions for the Suite Release Version of Conjur</h2>
+    Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.
+
+    <ul>
+      <li>
+        <b>Docker or docker-compose</b>
+
+        <p>
+        Set the container image tag to <code>cyberark/conjur:1.4.4</code>. For
+        example, make the following update to the conjur service in the
+        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml">quickstart docker-compose.yml</a>:
+        </p>
+
+        <pre><code>image: cyberark/conjur:1.4.4</code></pre>
+      </li>
+      <li>
+        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart">Conjur OSS Helm chart</a></b>
+
+        <p>
+        Update the <code>image.tag</code> value and use the appropriate release of the helm
+        chart:
+        </p>
+
+        <pre><code>helm install ... \
+  --set image.tag="1.4.4" \
+  ...
+  https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v1.3.8/conjur-oss-1.3.8.tgz</code></pre>
       </li>
     </ul>
 

--- a/templates/testdata/RELEASE_NOTES_unified.md
+++ b/templates/testdata/RELEASE_NOTES_unified.md
@@ -33,14 +33,6 @@ Installing the Suite Release Version of Conjur requires setting the container im
   image: cyberark/conjur:1.4.4
   ```
 
-+ [**Cloud Formation templates for AWS**](https://github.com/cyberark/conjur-aws)
-
-  Set the environment variable CONJUR_VERSION before building the AMI:
-  ```
-  export CONJUR_VERSION="1.4.4"
-  ./build-ami.sh
-  ```
-
 ## Upgrade Instructions
 
 Upgrade instructions are available for the following components:

--- a/templates/testdata/RELEASE_NOTES_unified.md
+++ b/templates/testdata/RELEASE_NOTES_unified.md
@@ -17,6 +17,7 @@ to their releases:
 
 ### Conjur Core
 - **[cyberark/conjur v1.4.4](https://github.com/cyberark/conjur/releases/tag/v1.4.4)** (2020-01-03) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-007BFF)](https://github.com/cyberark/conjur)
+- **[cyberark/conjur-oss-helm-chart v1.3.8](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8)** (2020-05-03) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Trusted-007BFF)](https://github.com/cyberark/conjur-oss-helm-chart)
 
 ### Secrets Delivery
 - **[cyberark/secretless-broker v1.4.2](https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2)** (2020-01-08) [![Certification Level](https://img.shields.io/badge/Certification%20Level-Certified-6C757D)](https://github.com/cyberark/secretless-broker)
@@ -31,6 +32,16 @@ Installing the Suite Release Version of Conjur requires setting the container im
   For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
   ```
   image: cyberark/conjur:1.4.4
+  ```
+
++ [**Conjur OSS Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)
+
+  Update the `image.tag` value and use the appropriate release of the helm chart:
+  ```
+  helm install ... \
+    --set image.tag="1.4.4" \
+    ...
+    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v1.3.8/conjur-oss-1.3.8.tgz
   ```
 
 ## Upgrade Instructions

--- a/templates/testdata/UNRELEASED_CHANGES_unified.md
+++ b/templates/testdata/UNRELEASED_CHANGES_unified.md
@@ -17,6 +17,7 @@ These are the component versions that have yet not been included in the Conjur O
 - [cyberark/conjur v1.3.6 (2020-02-01)](https://github.com/cyberark/conjur/releases/tag/v1.3.6)
 - [cyberark/conjur v1.4.4 (2020-01-03)](https://github.com/cyberark/conjur/releases/tag/v1.4.4)
 - [cyberark/conjur @HEAD](https://github.com/cyberark/conjur/compare/v1.4.4...HEAD)
+- [cyberark/conjur-oss-helm-chart @HEAD](https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.3.8...HEAD)
 
 ### Secrets Delivery
 


### PR DESCRIPTION
This change adds installation instructions to generated `docs-release`
artifacts as they are needed there for our users. This change also removes out
AMI-specific update instructions from all templates as we don't maintain those
anymore.