### PR TITLE
Add helm chart upgrade URL

### DIFF
--- a/suite.yml
+++ b/suite.yml
@@ -14,6 +14,7 @@ section:
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
+        upgrade_url: https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment
         version: v2.0.0
 
   - name: Conjur SDK


### PR DESCRIPTION
### What does this PR do?
Adds a link in the suite.yml to the helm upgrade instructions

Note: I manually generated the `v1.5.0+suite.1` HTML release notes with this change included and submitted them to be published in the docs, since I think including this link adds value. I confirmed that the diff between the HTM notes attached to the GH release and this new version is just these lines:
```
      <li>
        <p><a href="https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment ">cyberark/conjur-oss-helm-chart</a></p>
      </li>
```

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation