### PR TITLE
Update HTML release notes

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -127,6 +127,7 @@ func RunParser(options Options) error {
 		// TODO: Suite version should probably be read from some file
 		Version:          options.Version,
 		Date:             options.Date,
+		Description:      repoConfig.Section.Description,
 		SuiteCategories:  suiteCategories,
 		UnifiedChangelog: unifiedChangelog.String(),
 	}

--- a/pkg/cli/testdata/expected_docs-release_diff_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_diff_output.txt
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
+<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd" MadCap:conditions="project_conditions.OSS">
   <head></head>
   <body>
-    <h1>Release Notes</h1>
-    <p>The following components were included or enhanced in the Conjur OSS suite version unreleased.</p>
+    <h1>Version unreleased</h1>
+    <p>The following components are included or enhanced in the Conjur OSS suite version unreleased.</p>
 
     <h2>Components</h2>
     <p>The following components, with links to their GitHub releases, comprise the Conjur Open Source Suite:</p>
@@ -27,8 +27,9 @@
       This section should be in a partial on its own but we can't do that until issue
       https://github.com/cyberark/conjur-oss-helm-chart/issues/50 is done
     -->
-    <h2>Installation Instructions for the Suite Release Version of Conjur</h2>
-    Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.
+    <h2>Conjur OSS Suite installation</h2>
+    <p>Installing the Suite Release Version of Conjur requires setting the container image tag.</p>
+    <p>Follow the instructions relevant for your environment.</p>
 
     <ul>
       <li>

--- a/pkg/cli/testdata/expected_docs-release_diff_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_diff_output.txt
@@ -3,6 +3,7 @@
   <head></head>
   <body>
     <h1>Version unreleased</h1>
+    <p>These are the new primary repositories for Conjur Open Source and its SDK.</p>
     <p>The following components are included or enhanced in the Conjur OSS suite version unreleased.</p>
 
     <h2>Components</h2>

--- a/pkg/cli/testdata/expected_docs-release_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_output.txt
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
+<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd" MadCap:conditions="project_conditions.OSS">
   <head></head>
   <body>
-    <h1>Release Notes</h1>
-    <p>The following components were included or enhanced in the Conjur OSS suite version unreleased.</p>
+    <h1>Version unreleased</h1>
+    <p>The following components are included or enhanced in the Conjur OSS suite version unreleased.</p>
 
     <h2>Components</h2>
     <p>The following components, with links to their GitHub releases, comprise the Conjur Open Source Suite:</p>
@@ -33,8 +33,9 @@
       This section should be in a partial on its own but we can't do that until issue
       https://github.com/cyberark/conjur-oss-helm-chart/issues/50 is done
     -->
-    <h2>Installation Instructions for the Suite Release Version of Conjur</h2>
-    Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.
+    <h2>Conjur OSS Suite installation</h2>
+    <p>Installing the Suite Release Version of Conjur requires setting the container image tag.</p>
+    <p>Follow the instructions relevant for your environment.</p>
 
     <ul>
       <li>

--- a/pkg/cli/testdata/expected_docs-release_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_output.txt
@@ -3,6 +3,7 @@
   <head></head>
   <body>
     <h1>Version unreleased</h1>
+    <p>These are the primary repositories for Conjur Open Source and its SDK.</p>
     <p>The following components are included or enhanced in the Conjur OSS suite version unreleased.</p>
 
     <h2>Components</h2>

--- a/pkg/cli/testdata/new_release_suite.yml
+++ b/pkg/cli/testdata/new_release_suite.yml
@@ -1,7 +1,7 @@
 ---
 section:
   name: Conjur OSS Suite Release
-  description: These are the primary repositories for Conjur Open Source and its SDK.
+  description: These are the new primary repositories for Conjur Open Source and its SDK.
   categories:
   - name: Conjur OSS Core
     description: Conjur OSS Server and Deployment Tools

--- a/pkg/cli/testdata/suite.yml
+++ b/pkg/cli/testdata/suite.yml
@@ -1,6 +1,7 @@
 ---
 section:
   name: Conjur OSS Suite Release
+  version: 1.2.3
   description: These are the primary repositories for Conjur Open Source and its SDK.
   categories:
   - name: Conjur OSS Core

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -31,7 +31,9 @@ type Category struct {
 	Repos           []Repository
 }
 
-type section struct {
+// Section is the bulk of the suite configuration, and includes the description
+// of this specific release
+type Section struct {
 	describedObject `yaml:",inline"`
 	Categories      []Category
 }
@@ -39,7 +41,7 @@ type section struct {
 // Config is the toplevel object containing the layout of a suite.yml
 // file
 type Config struct {
-	Section section
+	Section Section
 }
 
 // NewConfig ingests a YAML file and returns a Config representing the definitions

--- a/pkg/repositories/repositories_test.go
+++ b/pkg/repositories/repositories_test.go
@@ -40,7 +40,7 @@ func testfileExpectedConfig(expectedRepos ...Repository) Config {
 	}
 
 	return Config{
-		Section: section{
+		Section: Section{
 			describedObject: describedObject{
 				Name:        "Section Name",
 				Description: "Section Description",

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -18,6 +18,7 @@ import (
 type ReleaseSuite struct {
 	Version          string
 	Date             time.Time
+	Description      string
 	SuiteCategories  []github.SuiteCategory
 	UnifiedChangelog string
 }

--- a/templates/RELEASE_NOTES_unified.htm.tmpl
+++ b/templates/RELEASE_NOTES_unified.htm.tmpl
@@ -6,6 +6,9 @@
   <head></head>
   <body>
     <h1>Version {{ toLower .Version }}</h1>
+{{- if .Description }}
+    <p>{{ .Description }}</p>
+{{- end }}
     <p>The following components are included or enhanced in the Conjur OSS suite version {{ toLower .Version }}.</p>
 
     <h2>Components</h2>

--- a/templates/RELEASE_NOTES_unified.htm.tmpl
+++ b/templates/RELEASE_NOTES_unified.htm.tmpl
@@ -2,11 +2,11 @@
 {{ $helmChartVersion := .ComponentReleaseVersion "cyberark/conjur-oss-helm-chart" -}}
 
 <?xml version="1.0" encoding="utf-8"?>
-<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
+<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd" MadCap:conditions="project_conditions.OSS">
   <head></head>
   <body>
-    <h1>Release Notes</h1>
-    <p>The following components were included or enhanced in the Conjur OSS suite version {{ toLower .Version }}.</p>
+    <h1>Version {{ toLower .Version }}</h1>
+    <p>The following components are included or enhanced in the Conjur OSS suite version {{ toLower .Version }}.</p>
 
     <h2>Components</h2>
     <p>The following components, with links to their GitHub releases, comprise the Conjur Open Source Suite:</p>
@@ -25,8 +25,9 @@
       This section should be in a partial on its own but we can't do that until issue
       https://github.com/cyberark/conjur-oss-helm-chart/issues/50 is done
     -->
-    <h2>Installation Instructions for the Suite Release Version of Conjur</h2>
-    Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.
+    <h2>Conjur OSS Suite installation</h2>
+    <p>Installing the Suite Release Version of Conjur requires setting the container image tag.</p>
+    <p>Follow the instructions relevant for your environment.</p>
 
     <ul>
       <li>

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -55,6 +55,7 @@ func TestTemplates(t *testing.T) {
 
 	testData := template.ReleaseSuite{
 		Version:          "11.22.33",
+		Description:      "A very special suite release.",
 		Date:             outputDate,
 		UnifiedChangelog: "@@@Unified changelog content@@@",
 		SuiteCategories: []github.SuiteCategory{

--- a/templates/testdata/RELEASE_NOTES_unified.htm
+++ b/templates/testdata/RELEASE_NOTES_unified.htm
@@ -3,6 +3,7 @@
   <head></head>
   <body>
     <h1>Version 11.22.33</h1>
+    <p>A very special suite release.</p>
     <p>The following components are included or enhanced in the Conjur OSS suite version 11.22.33.</p>
 
     <h2>Components</h2>

--- a/templates/testdata/RELEASE_NOTES_unified.htm
+++ b/templates/testdata/RELEASE_NOTES_unified.htm
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
+<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd" MadCap:conditions="project_conditions.OSS">
   <head></head>
   <body>
-    <h1>Release Notes</h1>
-    <p>The following components were included or enhanced in the Conjur OSS suite version 11.22.33.</p>
+    <h1>Version 11.22.33</h1>
+    <p>The following components are included or enhanced in the Conjur OSS suite version 11.22.33.</p>
 
     <h2>Components</h2>
     <p>The following components, with links to their GitHub releases, comprise the Conjur Open Source Suite:</p>
@@ -27,8 +27,9 @@
       This section should be in a partial on its own but we can't do that until issue
       https://github.com/cyberark/conjur-oss-helm-chart/issues/50 is done
     -->
-    <h2>Installation Instructions for the Suite Release Version of Conjur</h2>
-    Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.
+    <h2>Conjur OSS Suite installation</h2>
+    <p>Installing the Suite Release Version of Conjur requires setting the container image tag.</p>
+    <p>Follow the instructions relevant for your environment.</p>
 
     <ul>
       <li>


### PR DESCRIPTION
### What does this PR do?
- Updates HTML release note template to match v1.5.0+suite.1
  - In v1.5.0+suite.1, some minor tweaks were made to the release notes that we
    didn't backport to the automation. In this commit, we update the HTML release
    notes (and relevant test output) to ensure the auto-generated HTML we create
    this time includes these fixes.
- Adds suite description to HTML release notes output, so that each release will include
   the release-specific description in the release docs. 

### What ticket does this PR close?
Resolves #191 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation