### PR TITLE
Update suite.yml for v1.11.1+suite.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.11.1+suite.1] - 2020-12-04
+
 ### Changed
 - Updated Go version to 1.15. [cyberark/conjur-oss-suite-release#196](https://github.com/cyberark/conjur-oss-suite-release/issues/196)
 - Updates links in HTML output to include `target="_blank"` so that they will
   open in a new window, unless the link points to a CyberArk docs site.
   [cyberark/conjur-oss-suite-release#199](https://github.com/cyberark/conjur-oss-suite-release/issues/199)
+
+[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.11.1+suite.1...HEAD
+[v1.11.1+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.10.0+suite.1...v1.11.1+suite.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,8 @@ Anyone can request a new suite release, if they believe it is merited.
 
    - Edit the [suite release config](https://github.com/cyberark/conjur-oss-suite-release/blob/master/suite.yml)
      to bump the versions of any components with new tags and/or to add any new components
-     to the next suite release.
+     to the next suite release. Also update the CHANGELOG to mark the new
+     version - there's no need to add an entry for the suite version bumps.
 
    - [Submit your changes in a pull request (PR)](https://docs.joomla.org/Using_the_Github_UI_to_Make_Pull_Requests)
      as per our [contributor guidelines](https://github.com/cyberark/community).

--- a/suite.yml
+++ b/suite.yml
@@ -11,12 +11,12 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.10.0
+        version: v1.11.1
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
         upgrade_url: https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment
-        version: v2.0.1
+        version: v2.0.2
 
   - name: Conjur SDK
     description: Conjur Command Line Interface (CLI) and Client Libraries
@@ -32,7 +32,7 @@ section:
       - name: cyberark/conjur-api-go
         url: https://github.com/cyberark/conjur-api-go
         description: Conjur Golang Client Library
-        version: v0.6.0
+        version: v0.6.1
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
@@ -40,7 +40,7 @@ section:
       - name: cyberark/conjur-api-python3
         url: https://github.com/cyberark/conjur-api-python3
         description: Conjur Python Client Library
-        version: v0.0.5
+        version: v0.1.1
       - name: cyberark/conjur-api-ruby
         url: https://github.com/cyberark/conjur-api-ruby
         description: Conjur Ruby Client Library
@@ -54,14 +54,14 @@ section:
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        version: v0.18.1
+        version: v0.19.0
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
         tool: Kubernetes
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        version: v1.1.0
+        version: v1.1.1
 
   - name: DevOps Tools
     description: Conjur OSS integrations with DevOps tools.
@@ -95,7 +95,7 @@ section:
         description: Secretless Broker can be used to securely connect your
           applications to services they need - without ever having to fetch or
           manage passwords and keys.
-        version: v1.7.0
+        version: v1.7.1
 
   - name: Summon
     description: Run your processes wrapped with Summon to ensure they have


### PR DESCRIPTION
### What does this PR do?
- Preps for v1.11.1+suite.1 release
- Fixes test failure that came from a change to real release notes

### What ticket does this PR close?
Resolves #194 

Release checklist: https://github.com/cyberark/conjur-oss-suite-release/wiki/v1.11.1-suite.1
Draft release notes: https://gist.github.com/izgeri/0a60f26246decfdcac8fe1c5e3856abf
Early draft of docs output: [ConjurSuite.htm.zip](https://github.com/cyberark/conjur-oss-suite-release/files/5637762/ConjurSuite.htm.zip) - ~would like to resolve #199 before creating actual docs HTML~ - there is one manual change required to the docs link in the upgrade instructions section (so it won't pop up in a new window).


#### Release PRs
**If you are preparing for a release**, are the following items complete?
- [x] The PR title / description clearly state the suite release version.
- [x] The [Jenkins dashboard](https://jenkins.conjur.net/view/OSS%20Suite%20Components/) shows no ongoing
      build failures for any included components.
- [x] The PR includes a link to a markdown release notes draft - this can be
     generated by running:
     ```
     summon -p keyring.py   --yaml 'GITHUB_TOKEN: !var github/api_token' \
       ./parse-changelogs \
       -v {suite-version} \
       -t release
       -o RELEASE_NOTES.md
     ```
- [x] The PR includes PM-approved "What's new" text.
