### PR TITLE
Change test Docker Go image from stretch to buster

### DIFF
--- a/k8s-ci/Dockerfile
+++ b/k8s-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-stretch
+FROM golang:1.15-buster
 
 RUN mkdir -p /src
 WORKDIR /src


### PR DESCRIPTION
### What does this PR do?
The new stable Debian version is buster, so this Dockerfile needs to be updated accordingly. Without this change the Jenkins pipeline will fail.

### What ticket does this PR close?
Related to #196 - the Go 1.15 version bump means we needed to change the Debian base of the Go image we use

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation