### PR TITLE
Update HTML links to open in a new window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Updated Go version to 1.15. [cyberark/conjur-oss-suite-release#196](https://github.com/cyberark/conjur-oss-suite-release/issues/196)
+- Updates links in HTML output to include `target="_blank"` so that they will
+  open in a new window, unless the link points to a CyberArk docs site.
+  [cyberark/conjur-oss-suite-release#199](https://github.com/cyberark/conjur-oss-suite-release/issues/199)

--- a/pkg/cli/testdata/expected_changelog_output.txt
+++ b/pkg/cli/testdata/expected_changelog_output.txt
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `cyberark/conjur-api-go@0.6.0`: Converted to Golang 1.12
 - `cyberark/conjur-api-go@0.6.0`: Started using os.UserHomeDir() built-in instead of go-homedir module
 - `cyberark/conjur-api-java@2.0.0`: License updated to Apache v2 - [PR #8](https://github.com/cyberark/conjur-api-java/pull/8)
-- `cyberark/conjur-api-python3@0.0.5`: Added ability to delete policies [#23](https://github.com/cyberark/conjur-api-python3/issues/23)
+- `cyberark/conjur-api-python3@0.0.5`: Added ability to delete policies [cyberark/conjur-api-python3#23](https://github.com/cyberark/conjur-api-python3/issues/23)
 
 ### Changed
 - `cyberark/conjur@1.3.6`: Reduced IAM authentication logging

--- a/pkg/cli/testdata/expected_docs-release_diff_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_diff_output.txt
@@ -69,8 +69,7 @@
 
     <h2>What's New by Component</h2>
     <p>The following components were introduced or enhanced in the Conjur OSS suite version unreleased.</p>
-    <MadCap:listOfProxy style="mc-list-of-tag: h3;mc-list-of-class: list;mc-list-of-paragraph-class: RN;" />
-    <h3 class="list">cyberark/conjur</h3>
+    <h3 class="itt">cyberark/conjur</h3>
     <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.6" target="_blank">v1.4.6</a> (2020-01-21)</h4>
     <p><strong>Changed</strong></p>
     <ul>
@@ -99,7 +98,7 @@ from the id.</p>
         <p>Updated broken links on server status page (#1341)</p>
       </li>
     </ul>
-    <h3 class="list">cyberark/conjur-oss-helm-chart</h3>
+    <h3 class="itt">cyberark/conjur-oss-helm-chart</h3>
     <h4><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8" target="_blank">v1.3.8</a> (2019-12-20)</h4>
     <p><strong>Added</strong></p>
     <ul>

--- a/pkg/cli/testdata/expected_docs-release_diff_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_diff_output.txt
@@ -11,16 +11,16 @@
     <h3>Conjur OSS Core</h3>
     <ul>
       <li>
-        <p><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.7">cyberark/conjur v1.4.7</a> (2020-03-12)</p>
+        <p><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.7" target="_blank">cyberark/conjur v1.4.7</a> (2020-03-12)</p>
       </li>
       <li>
-        <p><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8">cyberark/conjur-oss-helm-chart v1.3.8</a> (2019-12-20)</p>
+        <p><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8" target="_blank">cyberark/conjur-oss-helm-chart v1.3.8</a> (2019-12-20)</p>
       </li>
     </ul>
     <h3>Conjur SDK</h3>
     <ul>
       <li>
-        <p><a href="https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5">cyberark/conjur-api-python3 v0.0.5</a> (2019-12-06)</p>
+        <p><a href="https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5" target="_blank">cyberark/conjur-api-python3 v0.0.5</a> (2019-12-06)</p>
       </li>
     </ul>
 
@@ -39,13 +39,13 @@
         <p>
         Set the container image tag to <code>cyberark/conjur:1.4.7</code>. For
         example, make the following update to the conjur service in the
-        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml">quickstart docker-compose.yml</a>:
+        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml" target="_blank">quickstart docker-compose.yml</a>:
         </p>
 
         <pre><code>image: cyberark/conjur:1.4.7</code></pre>
       </li>
       <li>
-        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart">Conjur OSS Helm chart</a></b>
+        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart" target="_blank">Conjur OSS Helm chart</a></b>
 
         <p>
         Update the <code>image.tag</code> value and use the appropriate release of the helm
@@ -63,7 +63,7 @@
     <p>Upgrade instructions are available for the following suite components:</p>
     <ul>
       <li>
-        <p><a href="https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm ">cyberark/conjur</a></p>
+        <p><a href="https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm" target="_blank">cyberark/conjur</a></p>
       </li>
     </ul>
 
@@ -71,7 +71,7 @@
     <p>The following components were introduced or enhanced in the Conjur OSS suite version unreleased.</p>
     <MadCap:listOfProxy style="mc-list-of-tag: h3;mc-list-of-class: list;mc-list-of-paragraph-class: RN;" />
     <h3 class="list">cyberark/conjur</h3>
-    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.6">v1.4.6</a> (2020-01-21)</h4>
+    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.6" target="_blank">v1.4.6</a> (2020-01-21)</h4>
     <p><strong>Changed</strong></p>
     <ul>
       <li>
@@ -80,7 +80,7 @@ defined in annotations it will taken from there and if not, it will be taken
 from the id.</p>
       </li>
     </ul>
-    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.7">v1.4.7</a> (2020-03-12)</h4>
+    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.7" target="_blank">v1.4.7</a> (2020-03-12)</h4>
     <p><strong>Changed</strong></p>
     <ul>
       <li>
@@ -100,7 +100,7 @@ from the id.</p>
       </li>
     </ul>
     <h3 class="list">cyberark/conjur-oss-helm-chart</h3>
-    <h4><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8">v1.3.8</a> (2019-12-20)</h4>
+    <h4><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8" target="_blank">v1.3.8</a> (2019-12-20)</h4>
     <p><strong>Added</strong></p>
     <ul>
       <li>

--- a/pkg/cli/testdata/expected_docs-release_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_output.txt
@@ -11,22 +11,22 @@
     <h3>Conjur OSS Core</h3>
     <ul>
       <li>
-        <p><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.6">cyberark/conjur v1.4.6</a> (2020-01-21)</p>
+        <p><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.6" target="_blank">cyberark/conjur v1.4.6</a> (2020-01-21)</p>
       </li>
       <li>
-        <p><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7">cyberark/conjur-oss-helm-chart v1.3.7</a> (2019-01-31)</p>
+        <p><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7" target="_blank">cyberark/conjur-oss-helm-chart v1.3.7</a> (2019-01-31)</p>
       </li>
     </ul>
     <h3>Conjur SDK</h3>
     <ul>
       <li>
-        <p><a href="https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5">cyberark/conjur-api-python3 v0.0.5</a> (2019-12-06)</p>
+        <p><a href="https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5" target="_blank">cyberark/conjur-api-python3 v0.0.5</a> (2019-12-06)</p>
       </li>
       <li>
-        <p><a href="https://github.com/cyberark/conjur-api-java/releases/tag/v2.0.0">cyberark/conjur-api-java v2.0.0</a> (2018-07-12)</p>
+        <p><a href="https://github.com/cyberark/conjur-api-java/releases/tag/v2.0.0" target="_blank">cyberark/conjur-api-java v2.0.0</a> (2018-07-12)</p>
       </li>
       <li>
-        <p><a href="https://github.com/cyberark/conjur-api-go/releases/tag/v0.6.0">cyberark/conjur-api-go v0.6.0</a> (2019-03-04)</p>
+        <p><a href="https://github.com/cyberark/conjur-api-go/releases/tag/v0.6.0" target="_blank">cyberark/conjur-api-go v0.6.0</a> (2019-03-04)</p>
       </li>
     </ul>
 
@@ -45,13 +45,13 @@
         <p>
         Set the container image tag to <code>cyberark/conjur:1.4.6</code>. For
         example, make the following update to the conjur service in the
-        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml">quickstart docker-compose.yml</a>:
+        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml" target="_blank">quickstart docker-compose.yml</a>:
         </p>
 
         <pre><code>image: cyberark/conjur:1.4.6</code></pre>
       </li>
       <li>
-        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart">Conjur OSS Helm chart</a></b>
+        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart" target="_blank">Conjur OSS Helm chart</a></b>
 
         <p>
         Update the <code>image.tag</code> value and use the appropriate release of the helm
@@ -69,7 +69,7 @@
     <p>Upgrade instructions are available for the following suite components:</p>
     <ul>
       <li>
-        <p><a href="https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm ">cyberark/conjur</a></p>
+        <p><a href="https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Deployment/Upgrade/upgrade-intro.htm" target="_blank">cyberark/conjur</a></p>
       </li>
     </ul>
 
@@ -77,7 +77,7 @@
     <p>The following components were introduced or enhanced in the Conjur OSS suite version unreleased.</p>
     <MadCap:listOfProxy style="mc-list-of-tag: h3;mc-list-of-class: list;mc-list-of-paragraph-class: RN;" />
     <h3 class="list">cyberark/conjur</h3>
-    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.3.6">v1.3.6</a> (2019-02-19)</h4>
+    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.3.6" target="_blank">v1.3.6</a> (2019-02-19)</h4>
     <p><strong>Changed</strong></p>
     <ul>
       <li>
@@ -93,7 +93,7 @@
         <p>Removed OIDC APIs public access</p>
       </li>
     </ul>
-    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.4">v1.4.4</a> (2019-12-19)</h4>
+    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.4" target="_blank">v1.4.4</a> (2019-12-19)</h4>
     <p><strong>Added</strong></p>
     <ul>
       <li>
@@ -133,7 +133,7 @@
         <p>Removed follower env configuration</p>
       </li>
     </ul>
-    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.6">v1.4.6</a> (2020-01-21)</h4>
+    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.6" target="_blank">v1.4.6</a> (2020-01-21)</h4>
     <p><strong>Changed</strong></p>
     <ul>
       <li>
@@ -143,7 +143,7 @@ from the id.</p>
       </li>
     </ul>
     <h3 class="list">cyberark/conjur-oss-helm-chart</h3>
-    <h4><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7">v1.3.7</a> (2019-01-31)</h4>
+    <h4><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7" target="_blank">v1.3.7</a> (2019-01-31)</h4>
     <p><strong>Changed</strong></p>
     <ul>
       <li>
@@ -151,32 +151,32 @@ from the id.</p>
       </li>
     </ul>
     <h3 class="list">cyberark/conjur-api-python3</h3>
-    <h4><a href="https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5">v0.0.5</a> (2019-12-06)</h4>
+    <h4><a href="https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5" target="_blank">v0.0.5</a> (2019-12-06)</h4>
     <p><strong>Added</strong></p>
     <ul>
       <li>
-        <p>Added ability to delete policies <a href="https://github.com/cyberark/conjur-api-python3/issues/23">#23</a></p>
+        <p>Added ability to delete policies <a href="https://github.com/cyberark/conjur-api-python3/issues/23" target="_blank">cyberark/conjur-api-python3#23</a></p>
       </li>
     </ul>
     <h3 class="list">cyberark/conjur-api-java</h3>
-    <h4><a href="https://github.com/cyberark/conjur-api-java/releases/tag/v2.0.0">v2.0.0</a> (2018-07-12)</h4>
+    <h4><a href="https://github.com/cyberark/conjur-api-java/releases/tag/v2.0.0" target="_blank">v2.0.0</a> (2018-07-12)</h4>
     <p><strong>Added</strong></p>
     <ul>
       <li>
-        <p>License updated to Apache v2 - <a href="https://github.com/cyberark/conjur-api-java/pull/8">PR #8</a></p>
+        <p>License updated to Apache v2 - <a href="https://github.com/cyberark/conjur-api-java/pull/8" target="_blank">PR #8</a></p>
       </li>
     </ul>
     <p><strong>Changed</strong></p>
     <ul>
       <li>
-        <p>Authn tokens now use the new Conjur 5 format - <a href="https://github.com/cyberark/conjur-api-java/pull/21">PR #21</a></p>
+        <p>Authn tokens now use the new Conjur 5 format - <a href="https://github.com/cyberark/conjur-api-java/pull/21" target="_blank">PR #21</a></p>
       </li>
       <li>
-        <p>Configuration change. When using environment variables, use CONJUR_AUTHN_LOGIN and CONJUR_AUTHN_API_KEY now instead of CONJUR_CREDENTIALS - <a href="https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb">https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb</a></p>
+        <p>Configuration change. When using environment variables, use CONJUR_AUTHN_LOGIN and CONJUR_AUTHN_API_KEY now instead of CONJUR_CREDENTIALS - <a href="https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb" target="_blank">https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb</a></p>
       </li>
     </ul>
     <h3 class="list">cyberark/conjur-api-go</h3>
-    <h4><a href="https://github.com/cyberark/conjur-api-go/releases/tag/v0.6.0">v0.6.0</a> (2019-03-04)</h4>
+    <h4><a href="https://github.com/cyberark/conjur-api-go/releases/tag/v0.6.0" target="_blank">v0.6.0</a> (2019-03-04)</h4>
     <p><strong>Added</strong></p>
     <ul>
       <li>

--- a/pkg/cli/testdata/expected_docs-release_output.txt
+++ b/pkg/cli/testdata/expected_docs-release_output.txt
@@ -75,8 +75,7 @@
 
     <h2>What's New by Component</h2>
     <p>The following components were introduced or enhanced in the Conjur OSS suite version unreleased.</p>
-    <MadCap:listOfProxy style="mc-list-of-tag: h3;mc-list-of-class: list;mc-list-of-paragraph-class: RN;" />
-    <h3 class="list">cyberark/conjur</h3>
+    <h3 class="itt">cyberark/conjur</h3>
     <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.3.6" target="_blank">v1.3.6</a> (2019-02-19)</h4>
     <p><strong>Changed</strong></p>
     <ul>
@@ -142,7 +141,7 @@ defined in annotations it will taken from there and if not, it will be taken
 from the id.</p>
       </li>
     </ul>
-    <h3 class="list">cyberark/conjur-oss-helm-chart</h3>
+    <h3 class="itt">cyberark/conjur-oss-helm-chart</h3>
     <h4><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.7" target="_blank">v1.3.7</a> (2019-01-31)</h4>
     <p><strong>Changed</strong></p>
     <ul>
@@ -150,7 +149,7 @@ from the id.</p>
         <p>Server ciphers have been upgraded to TLS1.2 levels.</p>
       </li>
     </ul>
-    <h3 class="list">cyberark/conjur-api-python3</h3>
+    <h3 class="itt">cyberark/conjur-api-python3</h3>
     <h4><a href="https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5" target="_blank">v0.0.5</a> (2019-12-06)</h4>
     <p><strong>Added</strong></p>
     <ul>
@@ -158,7 +157,7 @@ from the id.</p>
         <p>Added ability to delete policies <a href="https://github.com/cyberark/conjur-api-python3/issues/23" target="_blank">cyberark/conjur-api-python3#23</a></p>
       </li>
     </ul>
-    <h3 class="list">cyberark/conjur-api-java</h3>
+    <h3 class="itt">cyberark/conjur-api-java</h3>
     <h4><a href="https://github.com/cyberark/conjur-api-java/releases/tag/v2.0.0" target="_blank">v2.0.0</a> (2018-07-12)</h4>
     <p><strong>Added</strong></p>
     <ul>
@@ -175,7 +174,7 @@ from the id.</p>
         <p>Configuration change. When using environment variables, use CONJUR_AUTHN_LOGIN and CONJUR_AUTHN_API_KEY now instead of CONJUR_CREDENTIALS - <a href="https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb" target="_blank">https://github.com/cyberark/conjur-api-java/commit/60344308fc48cb5380c626e612b91e1e720c03fb</a></p>
       </li>
     </ul>
-    <h3 class="list">cyberark/conjur-api-go</h3>
+    <h3 class="itt">cyberark/conjur-api-go</h3>
     <h4><a href="https://github.com/cyberark/conjur-api-go/releases/tag/v0.6.0" target="_blank">v0.6.0</a> (2019-03-04)</h4>
     <p><strong>Added</strong></p>
     <ul>

--- a/pkg/cli/testdata/expected_release_output.txt
+++ b/pkg/cli/testdata/expected_release_output.txt
@@ -98,7 +98,7 @@ from the id.
 
 #### [v0.0.5](https://github.com/cyberark/conjur-api-python3/releases/tag/v0.0.5) (2019-12-06)
 * **Added**
-    - Added ability to delete policies [#23](https://github.com/cyberark/conjur-api-python3/issues/23)
+    - Added ability to delete policies [cyberark/conjur-api-python3#23](https://github.com/cyberark/conjur-api-python3/issues/23)
 
 ### cyberark/conjur-api-java
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -142,10 +142,12 @@ func (r ReleaseSuite) ComponentReleaseVersion(repo string) string {
 
 func markdownHyperlinksToHTMLHyperlinks(sectionItem string) string {
 	linkTemplate := `<a href="%s">%s</a>`
+	linkTemplateNewWindow := `<a href="%s" target="_blank">%s</a>`
 
 	markdownRegex := regexp.MustCompile(`\[(.*?)\]\((.*?)\)`)
 	nameRegex := regexp.MustCompile(`\[(.*)\]`)
 	urlRegex := regexp.MustCompile(`\((.*)\)`)
+	docsURLRegex := regexp.MustCompile(`docs\.(conjur|cyberark)\.(org|com)`)
 
 	links := markdownRegex.FindAllString(sectionItem, -1)
 
@@ -158,7 +160,11 @@ func markdownHyperlinksToHTMLHyperlinks(sectionItem string) string {
 		name = strings.Replace(name, "[", "", 1)
 		name = strings.Replace(name, "]", "", 1)
 
-		htmlLink := fmt.Sprintf(linkTemplate, url, name)
+		// Only ask link to open in a new window if it's not a docs link
+		htmlLink := fmt.Sprintf(linkTemplateNewWindow, url, name)
+		if docsURLRegex.FindString(url) != "" {
+			htmlLink = fmt.Sprintf(linkTemplate, url, name)
+		}
 
 		sectionItem = strings.Replace(sectionItem, markdownLink, htmlLink, 1)
 	}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -152,12 +152,22 @@ func TestMarkdownHyperlinksToHTMLHyperlinks(t *testing.T) {
 		{
 			description:    `input contains a single url`,
 			inputString:    `foo [bar](baz)`,
-			expectedString: `foo <a href="baz">bar</a>`,
+			expectedString: `foo <a href="baz" target="_blank">bar</a>`,
+		},
+		{
+			description:    `input contains a single conjur docs url`,
+			inputString:    `foo [bar](https://docs.conjur.org/baz)`,
+			expectedString: `foo <a href="https://docs.conjur.org/baz">bar</a>`,
+		},
+		{
+			description:    `input contains a single cyberark docs url`,
+			inputString:    `foo [bar](https://docs.cyberark.com/baz)`,
+			expectedString: `foo <a href="https://docs.cyberark.com/baz">bar</a>`,
 		},
 		{
 			description:    `input contains multiple urls`,
 			inputString:    `foo [bar](baz) & [jack](box)`,
-			expectedString: `foo <a href="baz">bar</a> & <a href="box">jack</a>`,
+			expectedString: `foo <a href="baz" target="_blank">bar</a> & <a href="box" target="_blank">jack</a>`,
 		},
 	}
 

--- a/templates/RELEASE_NOTES_unified.htm.tmpl
+++ b/templates/RELEASE_NOTES_unified.htm.tmpl
@@ -78,12 +78,11 @@
 
     <h2>What's New by Component</h2>
     <p>The following components were introduced or enhanced in the Conjur OSS suite version {{ toLower .Version }}.</p>
-    <MadCap:listOfProxy style="mc-list-of-tag: h3;mc-list-of-class: list;mc-list-of-paragraph-class: RN;" />
 
     {{- range .SuiteCategories }}
     {{- range .Components }}
     {{- if ne (len .Changelogs) 0 }}
-    <h3 class="list">{{ .Repo }}</h3>
+    <h3 class="itt">{{ .Repo }}</h3>
     {{- range .Changelogs }}
     <h4><a href="https://github.com/{{ .Repo }}/releases/tag/v{{ .Version }}" target="_blank">v{{ .Version }}</a> ({{ .Date }})</h4>
     {{- range $sectionKey, $sectionValues := .Sections }}

--- a/templates/RELEASE_NOTES_unified.htm.tmpl
+++ b/templates/RELEASE_NOTES_unified.htm.tmpl
@@ -18,7 +18,7 @@
     <ul>
       {{- range .Components }}
       <li>
-        <p><a href="https://github.com/{{ .Repo }}/releases/tag/{{ .ReleaseName }}">{{ .Repo }} {{ .ReleaseName }}</a> ({{ .ReleaseDate }})</p>
+        <p><a href="https://github.com/{{ .Repo }}/releases/tag/{{ .ReleaseName }}" target="_blank">{{ .Repo }} {{ .ReleaseName }}</a> ({{ .ReleaseDate }})</p>
       </li>
       {{- end }}
     </ul>
@@ -39,7 +39,7 @@
         <p>
         Set the container image tag to <code>cyberark/conjur:{{$conjurVersion}}</code>. For
         example, make the following update to the conjur service in the
-        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml">quickstart docker-compose.yml</a>:
+        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml" target="_blank">quickstart docker-compose.yml</a>:
         </p>
 
         <pre><code>image: cyberark/conjur:{{$conjurVersion}}</code></pre>
@@ -47,7 +47,7 @@
 
 {{- if $helmChartVersion }}
       <li>
-        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart">Conjur OSS Helm chart</a></b>
+        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart" target="_blank">Conjur OSS Helm chart</a></b>
 
         <p>
         Update the <code>image.tag</code> value and use the appropriate release of the helm
@@ -69,7 +69,7 @@
       {{- range .Components }}
       {{- if .UpgradeURL }}
       <li>
-        <p><a href="{{ .UpgradeURL }} ">{{ .Repo }}</a></p>
+        <p><a href="{{ .UpgradeURL }}" target="_blank">{{ .Repo }}</a></p>
       </li>
       {{- end }}
       {{- end }}
@@ -85,7 +85,7 @@
     {{- if ne (len .Changelogs) 0 }}
     <h3 class="list">{{ .Repo }}</h3>
     {{- range .Changelogs }}
-    <h4><a href="https://github.com/{{ .Repo }}/releases/tag/v{{ .Version }}">v{{ .Version }}</a> ({{ .Date }})</h4>
+    <h4><a href="https://github.com/{{ .Repo }}/releases/tag/v{{ .Version }}" target="_blank">v{{ .Version }}</a> ({{ .Date }})</h4>
     {{- range $sectionKey, $sectionValues := .Sections }}
     <p><strong>{{ $sectionKey }}</strong></p>
     <ul>

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -120,9 +120,9 @@ func TestTemplates(t *testing.T) {
 								Version: "1.4.2",
 								Date:    secretlessReleaseDate.Format("2006-01-02"),
 								Sections: map[string][]string{
-									"Added":   []string{"Broker142Addition"},
-									"Changed": []string{"Broker142Change"},
-									"Removed": []string{"Broker142Removal"},
+									"Added":   []string{"Broker142Addition", "Broker142Addition With Link [my link](https://github.com/cyberark/conjur/issues/142)"},
+									"Changed": []string{"Broker142Change", "Broker142Change With Conjur Docs Link [my link](https://docs.conjur.org/sub-url)"},
+									"Removed": []string{"Broker142Removal", "Broker142Removal With CyberArk Docs Link [my link](https://docs.cyberark.com/sub-url)"},
 								},
 							},
 						},

--- a/templates/testdata/RELEASE_NOTES_unified.htm
+++ b/templates/testdata/RELEASE_NOTES_unified.htm
@@ -69,8 +69,7 @@
 
     <h2>What's New by Component</h2>
     <p>The following components were introduced or enhanced in the Conjur OSS suite version 11.22.33.</p>
-    <MadCap:listOfProxy style="mc-list-of-tag: h3;mc-list-of-class: list;mc-list-of-paragraph-class: RN;" />
-    <h3 class="list">cyberark/conjur</h3>
+    <h3 class="itt">cyberark/conjur</h3>
     <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.3.6" target="_blank">v1.3.6</a> (2020-02-01)</h4>
     <p><strong>Changed</strong></p>
     <ul>
@@ -112,7 +111,7 @@
         <p>144Fix</p>
       </li>
     </ul>
-    <h3 class="list">cyberark/secretless-broker</h3>
+    <h3 class="itt">cyberark/secretless-broker</h3>
     <h4><a href="https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2" target="_blank">v1.4.2</a> (2020-01-08)</h4>
     <p><strong>Added</strong></p>
     <ul>

--- a/templates/testdata/RELEASE_NOTES_unified.htm
+++ b/templates/testdata/RELEASE_NOTES_unified.htm
@@ -11,16 +11,16 @@
     <h3>Conjur Core</h3>
     <ul>
       <li>
-        <p><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.4">cyberark/conjur v1.4.4</a> (2020-01-03)</p>
+        <p><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.4" target="_blank">cyberark/conjur v1.4.4</a> (2020-01-03)</p>
       </li>
       <li>
-        <p><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8">cyberark/conjur-oss-helm-chart v1.3.8</a> (2020-05-03)</p>
+        <p><a href="https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v1.3.8" target="_blank">cyberark/conjur-oss-helm-chart v1.3.8</a> (2020-05-03)</p>
       </li>
     </ul>
     <h3>Secrets Delivery</h3>
     <ul>
       <li>
-        <p><a href="https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2">cyberark/secretless-broker v1.4.2</a> (2020-01-08)</p>
+        <p><a href="https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2" target="_blank">cyberark/secretless-broker v1.4.2</a> (2020-01-08)</p>
       </li>
     </ul>
 
@@ -39,13 +39,13 @@
         <p>
         Set the container image tag to <code>cyberark/conjur:1.4.4</code>. For
         example, make the following update to the conjur service in the
-        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml">quickstart docker-compose.yml</a>:
+        <a href="https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml" target="_blank">quickstart docker-compose.yml</a>:
         </p>
 
         <pre><code>image: cyberark/conjur:1.4.4</code></pre>
       </li>
       <li>
-        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart">Conjur OSS Helm chart</a></b>
+        <b><a href="https://github.com/cyberark/conjur-oss-helm-chart" target="_blank">Conjur OSS Helm chart</a></b>
 
         <p>
         Update the <code>image.tag</code> value and use the appropriate release of the helm
@@ -63,7 +63,7 @@
     <p>Upgrade instructions are available for the following suite components:</p>
     <ul>
       <li>
-        <p><a href="https://conjur_upgrade_url ">cyberark/conjur</a></p>
+        <p><a href="https://conjur_upgrade_url" target="_blank">cyberark/conjur</a></p>
       </li>
     </ul>
 
@@ -71,7 +71,7 @@
     <p>The following components were introduced or enhanced in the Conjur OSS suite version 11.22.33.</p>
     <MadCap:listOfProxy style="mc-list-of-tag: h3;mc-list-of-class: list;mc-list-of-paragraph-class: RN;" />
     <h3 class="list">cyberark/conjur</h3>
-    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.3.6">v1.3.6</a> (2020-02-01)</h4>
+    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.3.6" target="_blank">v1.3.6</a> (2020-02-01)</h4>
     <p><strong>Changed</strong></p>
     <ul>
       <li>
@@ -87,7 +87,7 @@
         <p>136Removal</p>
       </li>
     </ul>
-    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.4">v1.4.4</a> (2020-01-03)</h4>
+    <h4><a href="https://github.com/cyberark/conjur/releases/tag/v1.4.4" target="_blank">v1.4.4</a> (2020-01-03)</h4>
     <p><strong>Added</strong></p>
     <ul>
       <li>
@@ -113,11 +113,14 @@
       </li>
     </ul>
     <h3 class="list">cyberark/secretless-broker</h3>
-    <h4><a href="https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2">v1.4.2</a> (2020-01-08)</h4>
+    <h4><a href="https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2" target="_blank">v1.4.2</a> (2020-01-08)</h4>
     <p><strong>Added</strong></p>
     <ul>
       <li>
         <p>Broker142Addition</p>
+      </li>
+      <li>
+        <p>Broker142Addition With Link <a href="https://github.com/cyberark/conjur/issues/142" target="_blank">my link</a></p>
       </li>
     </ul>
     <p><strong>Changed</strong></p>
@@ -125,11 +128,17 @@
       <li>
         <p>Broker142Change</p>
       </li>
+      <li>
+        <p>Broker142Change With Conjur Docs Link <a href="https://docs.conjur.org/sub-url">my link</a></p>
+      </li>
     </ul>
     <p><strong>Removed</strong></p>
     <ul>
       <li>
         <p>Broker142Removal</p>
+      </li>
+      <li>
+        <p>Broker142Removal With CyberArk Docs Link <a href="https://docs.cyberark.com/sub-url">my link</a></p>
       </li>
     </ul>
   </body>

--- a/templates/testdata/RELEASE_NOTES_unified.md
+++ b/templates/testdata/RELEASE_NOTES_unified.md
@@ -78,7 +78,10 @@ OSS Suite release:
 #### [v1.4.2](https://github.com/cyberark/secretless-broker/releases/tag/v1.4.2) (2020-01-08)
 * **Added**
     - Broker142Addition
+    - Broker142Addition With Link [my link](https://github.com/cyberark/conjur/issues/142)
 * **Changed**
     - Broker142Change
+    - Broker142Change With Conjur Docs Link [my link](https://docs.conjur.org/sub-url)
 * **Removed**
     - Broker142Removal
+    - Broker142Removal With CyberArk Docs Link [my link](https://docs.cyberark.com/sub-url)

--- a/templates/testdata/UNRELEASED_CHANGES_unified.md
+++ b/templates/testdata/UNRELEASED_CHANGES_unified.md
@@ -54,9 +54,12 @@ as part of the OSS Suite:
 
 #### Added
 - Broker142Addition
+- Broker142Addition With Link [my link](https://github.com/cyberark/conjur/issues/142)
 
 #### Changed
 - Broker142Change
+- Broker142Change With Conjur Docs Link [my link](https://docs.conjur.org/sub-url)
 
 #### Removed
 - Broker142Removal
+- Broker142Removal With CyberArk Docs Link [my link](https://docs.cyberark.com/sub-url)


### PR DESCRIPTION
### What does this PR do?
Updates all relevant tests, including amending existing tests to verify that the
docs links are exempted and don't open in a new window.

Also fixes issue in CLI tests due to change made in actual python3 changelog.

Note: the upgrade instruction links all open in a new window, even though some of them are docs links. This is still a marked improvement from the current state, where every link needs to be hand-updated to add `target="_blank"` - now, just one or two links will need an update. When the helm chart docs are migrated to Flare, all upgrade links will point to docs sites and the `target="_blank"` additions in this section can be removed at that time. 

### What ticket does this PR close?
Resolves #199

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Release PRs
**If you are preparing for a release**, are the following items complete?
- [ ] The PR title / description clearly state the suite release version.
- [ ] The [Jenkins dashboard](https://jenkins.conjur.net/view/OSS%20Suite%20Components/) shows no ongoing
      build failures for any included components.
- [ ] The PR includes a link to a markdown release notes draft - this can be
     generated by running:
     ```
     summon -p keyring.py   --yaml 'GITHUB_TOKEN: !var github/api_token' \
       ./parse-changelogs \
       -v {suite-version} \
       -t release
       -o RELEASE_NOTES.md
     ```
- [ ] The PR includes PM-approved "What's new" text.
