### PR TITLE
Update strategy for determining tag version

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -42,8 +42,9 @@ jobs:
       with:
         go-version: 1.15
 
-    - name: Set GIT_BRANCH
-      run: echo "GIT_BRANCH={GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+    - name: Set up version info
+      id: get_version
+      uses: battila7/get-version-action@v2
 
     - name: Add suite.yml to artifacts
       uses: actions/upload-artifact@v1
@@ -52,7 +53,7 @@ jobs:
         name: suite.yml
 
     - name: Generate RELEASE_NOTES.md
-      run: go run cmd/changelog-parser/main.go -v "${GIT_BRANCH}" -t release -o tmp_RELEASE_NOTES.md
+      run: go run cmd/changelog-parser/main.go -v "${{ steps.get_version.outputs.version }}" -t release -o tmp_RELEASE_NOTES.md
 
     - name: Add RELEASE_NOTES to artifacts
       uses: actions/upload-artifact@v1
@@ -61,7 +62,7 @@ jobs:
         name: RELEASE_NOTES.md
 
     - name: Generate CHANGELOG.md
-      run: go run cmd/changelog-parser/main.go -v "${GIT_BRANCH}" -o tmp_CHANGELOG.md
+      run: go run cmd/changelog-parser/main.go -v "${{ steps.get_version.outputs.version }}" -o tmp_CHANGELOG.md
 
     - name: Add CHANGELOG to artifacts
       uses: actions/upload-artifact@v1
@@ -70,7 +71,7 @@ jobs:
         name: CHANGELOG.md
 
     - name: Generate ConjurSuite.htm
-      run: go run cmd/changelog-parser/main.go -v "${GIT_BRANCH}" -t docs-release -o tmp_ConjurSuite.htm
+      run: go run cmd/changelog-parser/main.go -v "${{ steps.get_version.outputs.version }}" -t docs-release -o tmp_ConjurSuite.htm
 
     - name: Add ConjurSuite to artifacts
       uses: actions/upload-artifact@v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,9 +30,6 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Set BRANCH_NAME
-      run: echo "GIT_BRANCH={GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-
     - name: Prepare CC for reporting data
       run: |
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- The draft release action is updated to use valid logic for determining the
+  suite version so that the draft release notes will include the correct
+  interpolated version.
+  [cyberark/conjur-oss-suite-release#212](https://github.com/cyberark/conjur-oss-suite-release/issues/212)
+
 ## [v1.11.2+suite.1] - 2021-02-10
 
 ### Added


### PR DESCRIPTION
### What does this PR do?
On the v1.11.2+suite.1 release we discovered that the draft-release workflow
was not correctly determining the version from the GITHUB_REFS env var. This
commit updates the logic to determine the version so that this will work
correctly on the next release.

Also removes unneeded version parsing from unit test flow.

### What ticket does this PR close?
Resolves #212

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### Release PRs
**If you are preparing for a release**, are the following items complete?
- [ ] The PR title / description clearly state the suite release version.
- [ ] The [Jenkins dashboard](https://jenkins.conjur.net/view/OSS%20Suite%20Components/) shows no ongoing
      build failures for any included components.
- [ ] The PR includes a link to a markdown release notes draft - this can be
     generated by running:
     ```
     summon -p keyring.py   --yaml 'GITHUB_TOKEN: !var github/api_token' \
       ./parse-changelogs \
       -v {suite-version} \
       -t release
       -o RELEASE_NOTES.md
     ```
- [ ] The PR includes PM-approved "What's new" text.
