### PR TITLE
Bump version v1.11.5+suite.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.11.5+suite.1] - 2021-04-14
+- The Python SDK is incremented to v7.0.1 to announce the release of the v7 CLI.
+
 ## [v1.11.3+suite.1] - 2021-03-09
 
 ### Fixed
@@ -46,7 +49,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   open in a new window, unless the link points to a CyberArk docs site.
   [cyberark/conjur-oss-suite-release#199](https://github.com/cyberark/conjur-oss-suite-release/issues/199)
 
-[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.11.3+suite.1...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.11.5+suite.1...HEAD
+[v1.11.5+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.3+suite.1...v1.11.5+suite.1
 [v1.11.3+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.2+suite.1...v1.11.3+suite.1
 [v1.11.2+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.1+suite.2...v1.11.2+suite.1
 [v1.11.1+suite.2]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.1+suite.1...v1.11.1+suite.2

--- a/suite.yml
+++ b/suite.yml
@@ -11,12 +11,12 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.11.3
+        version: v1.11.5
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
         upgrade_url: https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment
-        version: v2.0.3
+        version: v2.0.4
 
   - name: Conjur SDK
     description: Conjur Command Line Interface (CLI) and Client Libraries
@@ -40,7 +40,7 @@ section:
       - name: cyberark/conjur-api-python3
         url: https://github.com/cyberark/conjur-api-python3
         description: Conjur Python Client Library
-        version: v0.1.1
+        version: v7.0.1
       - name: cyberark/conjur-api-ruby
         url: https://github.com/cyberark/conjur-api-ruby
         description: Conjur Ruby Client Library
@@ -128,4 +128,4 @@ section:
       - name: cyberark/summon-conjur
         url: https://github.com/cyberark/summon-conjur
         description: Summon provider for Conjur.
-        version: v0.5.3
+        version: v0.5.4


### PR DESCRIPTION
### What does this PR do?
Updates Conjur, Helm chart, Python SDK

Release wiki page: https://github.com/cyberark/conjur-oss-suite-release/wiki/v1.11.5-suite.1
Draft release notes: https://gist.github.com/izgeri/f3004554c1c7c3523a642b63dab7a026
[ZenHub board](https://app.zenhub.com/workspaces/community-and-integrations-team-5e28ab8f700a191286d5abe0/board?releases=60632a8e46544061ee7e463a&repos=62174977,107414536,35568823,13068807,181756824,169479430,151117144,114040729,131041551,155729153,144302471,24191248,129415225,121428226,127067545,131177218,87459360,128110795,38008676,112209945,7396760,7396761,142046583,132513819,37145674,110738790,35956445,129148193,46360727,167067005,181513803,175443058,140766424,149802600,165913758,202615062,124427370,112222188,206022444,181930446,180458470,52056584,133858256,170183803,42073272,36090509,217348257,236054196,142932883,218336465,241929531,243799130,248887016,239805656,269868540,320296980)

What's New:
---
## What's New

This Suite release aligns with Conjur Server [version 1.11.5](https://github.com/cyberark/conjur/releases/tag/v1.11.5). It includes better error handling and more verbose default logs [in the Conjur server ](#cyberarkconjur), and a new and improved version of the Conjur CLI.

For a reminder of the Conjur Open Source Suite Release structure please refer to the documentation [introduction](https://docs.conjur.org/Latest/en/Content/Overview/Conjur-OSS-Suite-Overview.html?#StructureofConjurOpenSourceSuite).

Notable updates :


#### Conjur Server

This release includes several changes to continue to improve error handling by the Conjur server and to add more detail to the default INFO logs to facilitate troubleshooting in cases of server misconfiguration. In addition, the `conjurctl server` and `conjurctl account` commands now allow the operator to specify the admin user's password via STDIN when configuring the Conjur server on deploy.

#### New Conjur CLI !

The new Conjur CLI introduces improved security and an enhanced user experience by providing interactive commands, embedded help hints, and examples for easier usage. You can run the Conjur CLI on Microsoft Windows, Red Hat Enterprise Linux 7/8, and macOS with no need for a preliminary Docker installation. 
Reference the [install instructions](https://github.com/cyberark/conjur-api-python3/#install-the-conjur-cli) to download and try the new CLI.


#### OpenShift 4.6 

This release is validated for OpenShift 4.6:
- Conjur [deployment](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss) into OpenShift  (the helm chart is now at [Trusted](https://github.com/cyberark/community/blob/master/Conjur/conventions/certification-levels.md#trusted) level)
- [Authenticating workloads](https://docs.conjur.org/Latest/en/Content/Integrations/Kubernetes_deployApplicationCluster.htm?TocPath=Integrations%7COpenShift%2C%20Kubernetes%7C_____4) running in OpenShift.
- Consuming secrets with [Secretless](https://docs.conjur.org/Latest/en/Content/Get%20Started/scl_using-conjur-OSS.htm) 
- Consuming secrets with the [Secrets Provider for K8s](https://docs.conjur.org/Latest/en/Content/Integrations/k8s-ocp/cjr-secrets-provider-lp.htm)

Note that OpenShift versions 4.3 and 4.4 have reached end of life and are no longer validated.

---


### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### Release PRs
**If you are preparing for a release**, are the following items complete?
- [x] The PR title / description clearly state the suite release version.
- [x] The [Jenkins dashboard](https://jenkins.conjur.net/view/OSS%20Suite%20Components/) shows no ongoing
      build failures for any included components.
- [x] The PR includes a link to a markdown release notes draft - this can be
     generated by running:
     ```
     summon -p keyring.py   --yaml 'GITHUB_TOKEN: !var github/api_token' \
       ./parse-changelogs \
       -v {suite-version} \
       -t release
       -o RELEASE_NOTES.md
     ```
- [x] The PR includes PM-approved "What's new" text.
