### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ This works as follows:
   release will be versioned `1.x.y+suite.1`, where `1.x.y` matches the included
   Conjur core version.
 
-- Subsequent suite releases using the same Conjur OSS version require that the suite version build component be incremented.  For example, a second suite release using Conjur `1.2.3` should be versioned `1.2.3+suite.2`, as the first one would have been versioned as `1.2.3+suite.1`.
+- Subsequent suite releases using the same Conjur Open Source version require that the suite version build component be incremented.  For example, a second suite release using Conjur `1.2.3` should be versioned `1.2.3+suite.2`, as the first one would have been versioned as `1.2.3+suite.1`.
 
 Additional notes:
 - If Conjur changes its version with a new **minor or patch** release, we _may_

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ where you can:
 - Find out which version of Conjur to use, and which corresponding versions of
   the suite components are compatible with it
 
-If you're using Conjur OSS, we **strongly recommend** that you reference the latest
+If you're using Conjur Open Source, we **strongly recommend** that you reference the latest
 suite release (link TBA) to determine which version of Conjur to use, and which corresponding
 versions of the suite are compatible with it.
 

--- a/pkg/cli/testdata/expected_release_diff_output.txt
+++ b/pkg/cli/testdata/expected_release_diff_output.txt
@@ -34,7 +34,7 @@ Installing the Suite Release Version of Conjur requires setting the container im
   image: cyberark/conjur:1.4.7
   ```
 
-+ [**Conjur OSS Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)
++ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)
 
   Update the `image.tag` value and use the appropriate release of the helm chart:
   ```

--- a/pkg/cli/testdata/expected_release_output.txt
+++ b/pkg/cli/testdata/expected_release_output.txt
@@ -36,7 +36,7 @@ Installing the Suite Release Version of Conjur requires setting the container im
   image: cyberark/conjur:1.4.6
   ```
 
-+ [**Conjur OSS Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)
++ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)
 
   Update the `image.tag` value and use the appropriate release of the helm chart:
   ```

--- a/templates/partials/conjur_installation_instructions.md
+++ b/templates/partials/conjur_installation_instructions.md
@@ -11,7 +11,7 @@ Installing the Suite Release Version of Conjur requires setting the container im
   ```
 {{- if $helmChartVersion }}
 
-+ [**Conjur OSS Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)
++ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)
 
   Update the `image.tag` value and use the appropriate release of the helm chart:
   ```

--- a/templates/testdata/RELEASE_NOTES_unified.md
+++ b/templates/testdata/RELEASE_NOTES_unified.md
@@ -34,7 +34,7 @@ Installing the Suite Release Version of Conjur requires setting the container im
   image: cyberark/conjur:1.4.4
   ```
 
-+ [**Conjur OSS Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)
++ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)
 
   Update the `image.tag` value and use the appropriate release of the helm chart:
   ```


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
