### PR TITLE
Update suite.yml for v1.11.7+suite.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.11.7+suite.1] - 2021-07-07
+
 ## [v1.11.6+suite.1] - 2021-05-11
 
 ### Added
@@ -56,7 +58,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   open in a new window, unless the link points to a CyberArk docs site.
   [cyberark/conjur-oss-suite-release#199](https://github.com/cyberark/conjur-oss-suite-release/issues/199)
 
-[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.11.6+suite.1...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.11.7+suite.1...HEAD
+[v1.11.7+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.6+suite.1...v1.11.7+suite.1
 [v1.11.6+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.5+suite.1...v1.11.6+suite.1
 [v1.11.5+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.3+suite.1...v1.11.5+suite.1
 [v1.11.3+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.2+suite.1...v1.11.3+suite.1

--- a/suite.yml
+++ b/suite.yml
@@ -11,7 +11,7 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.11.6
+        version: v1.11.7
       - name: cyberark/conjur-openapi-spec
         url: https://github.com/cyberark/conjur-openapi-spec
         description: Conjur OpenAPI v3 specification
@@ -58,7 +58,7 @@ section:
         description: The Conjur Buildpack will use the Conjur identity provided
           by the Conjur Service Broker to inject secrets into your application
           environment at runtime.
-        version: v2.2.0
+        version: v2.2.1
       - name: cyberark/conjur-service-broker
         url: https://github.com/cyberark/conjur-service-broker
         description: The Conjur Service Broker provides your applications running
@@ -69,7 +69,7 @@ section:
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        version: v0.19.1
+        version: v0.21.0
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
         tool: Kubernetes


### PR DESCRIPTION
# Release Notes
All notable changes to this project will be documented in this file.

## [v1.11.7+suite.1] - 2021-07-06

## Table of Contents

- [Components](#components)
- [Installation Instructions for the Suite Release Version of Conjur](#installation-instructions-for-the-suite-release-version-of-conjur)
- [Upgrade Instructions](#upgrade-instructions)
- [Changes](#changes)

## Components

These are the components that combine to create this Conjur OSS Suite release and links
to their releases:

### Conjur Server
- **[cyberark/conjur v1.11.7](https://github.com/cyberark/conjur/releases/tag/v1.11.7)** (2021-06-08)
- **[cyberark/conjur-openapi-spec v5.1.1](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.1.1)** (2021-04-28)
- **[cyberark/conjur-oss-helm-chart v2.0.4](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.4)** (2021-04-12)

### Conjur SDK
- **[cyberark/conjur-cli v6.2.3](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.3)** (2020-12-22)
- **[cyberark/conjur-api-dotnet v2.0.0](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.0.0)** (2020-06-10)
- **[cyberark/conjur-api-go v0.7.1](https://github.com/cyberark/conjur-api-go/releases/tag/v0.7.1)** (2021-03-01)
- **[cyberark/conjur-api-java v3.0.2](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.2)** (2020-10-28)
- **[cyberark/conjur-api-python3 v7.0.1](https://github.com/cyberark/conjur-api-python3/releases/tag/v7.0.1)** (2020-04-12)
- **[cyberark/conjur-api-ruby v5.3.5](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.3.5)** (2021-05-04)

### Platform Integrations
- **[cyberark/cloudfoundry-conjur-buildpack v2.2.1](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.1)** (2020-06-24)
- **[cyberark/conjur-service-broker v1.1.5](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.1.5)** (2021-03-01)
- **[cyberark/conjur-authn-k8s-client v0.21.0](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.21.0)** (2021-06-25)
- **[cyberark/secrets-provider-for-k8s v1.1.3](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.1.3)** (2021-03-01)

### DevOps Tools
- **[cyberark/ansible-conjur-collection v1.1.0](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.1.0)** (2020-12-29)
- **[cyberark/ansible-conjur-host-identity v0.3.2](https://github.com/cyberark/ansible-conjur-host-identity/releases/tag/v0.3.2)** (2020-12-29)
- **[cyberark/conjur-puppet v3.1.0](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.0)** (2020-10-08)
- **[cyberark/terraform-provider-conjur v0.5.0](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.5.0)** (2021-05-06)

### Secretless Broker
- **[cyberark/secretless-broker v1.7.3](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.3)** (2021-03-09)

### Summon
- **[cyberark/summon v0.8.4](https://github.com/cyberark/summon/releases/tag/v0.8.4)** (2021-05-04)
- **[cyberark/summon-conjur v0.5.4](https://github.com/cyberark/summon-conjur/releases/tag/v0.5.4)** (2021-03-16)

## Installation Instructions for the Suite Release Version of Conjur

Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.

+ **Docker or docker-compose**

  Set the container image tag to `cyberark/conjur:1.11.7`.
  For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
  ```
  image: cyberark/conjur:1.11.7
  ```

+ [**Conjur OSS Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

  Update the `image.tag` value and use the appropriate release of the helm chart:
  ```
  helm install ... \
    --set image.tag="1.11.7" \
    ...
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v2.0.4/conjur-oss-2.0.4.tgz
  ```

## Upgrade Instructions

Upgrade instructions are available for the following components:
- [cyberark/conjur](https://github.com/cyberark/conjur/blob/master/UPGRADING.md)
- [cyberark/conjur-oss-helm-chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)

## Changes
The following are changes to the constituent components since the last Conjur
OSS Suite release:
- [cyberark/conjur](#cyberarkconjur)
- [cyberark/cloudfoundry-conjur-buildpack](#cyberarkcloudfoundry-conjur-buildpack)
- [cyberark/conjur-authn-k8s-client](#cyberarkconjur-authn-k8s-client)

### cyberark/conjur

#### [v1.11.7](https://github.com/cyberark/conjur/releases/tag/v1.11.7) (2021-06-08)
* **Added**
    - Enabled authenticators can now be configured via a configuration file, or the
CONJUR_AUTHENTICATORS environment variable.
[cyberark/conjur#2173](https://github.com/cyberark/conjur/issues/2173)
    - Trusted Proxies can now be configured with a configuration file or by setting
the CONJUR_TRUSTED_PROXIES environment variable.
[cyberark/conjur#2168](https://github.com/cyberark/conjur/issues/2168)
    - Added conjurctl configuration show command to print the Conjur configuration
values and the sources they are loaded from.
[cyberark/conjur#2169](https://github.com/cyberark/conjur/issues/2169)
    - Added conjurctl configuration apply command restart the Conjur process and
pick up changes to the configuration file.
[cyberark/conjur#2171](https://github.com/cyberark/conjur/issues/2171)
* **Fixed**
    - Fix bug where running conjurctl server or conjurctl account create with
passwords that contain ,s sent via stdin raised an error.
[cyberark/conjur#2159](https://github.com/cyberark/conjur/issues/2159)
    - Update the default keepalive timeout for puma to be longer than most common proxy and load balancers.
Previously, the load balancer in front of Conjur would commonly have a longer timeout than the
server itself, which can lead to Conjur closing connections even as there are pending requests and
the proxy returning 502 errors to the client.
[PR cyberark/conjur#2191](https://github.com/cyberark/conjur/pull/2191)
* **Security**
    - Upgrade Rails to 5.2.5 to resolve CVE-2021-22885
[cyberark/conjur#2149](https://github.com/cyberark/conjur/issues/2149)
    - Upgrade Nokogiri to 1.11.5 to resolve
[GHSA-7rrm-v45f-jp64](https://github.com/advisories/GHSA-7rrm-v45f-jp64).
    - Upgrade Puma to 4.3.8 to resolve
[CVE-2021-29509](https://nvd.nist.gov/vuln/detail/CVE-2021-29509).
    - Upgrade Bundler to 2.2.18 to resolve
[CVE-2020-36327](https://nvd.nist.gov/vuln/detail/CVE-2020-36327).

### cyberark/cloudfoundry-conjur-buildpack

#### [v2.2.1](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.1) (2020-06-24)
* **Fixed**
    - Fixed scrambled error messages (e.g. with invalid line numbers) that were
generated whenever the Cloudfoundry Buildpack encountered errors while
parsing environment variable settings after retrieving secrets variables
from Conjur.
[cyberark/cloudfoundry-conjur-buildpack#120](https://github.com/cyberark/cloudfoundry-conjur-buildpack/issues/120)

### cyberark/conjur-authn-k8s-client

#### [v0.20.0](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.20.0) (2021-06-16)
* **Changed**
    - The CAKC048 log message now shows the release version for release builds
and no longer includes the git commit hash in the log output.
[cyberark/conjur-authn-k8s-client#196](https://github.com/cyberark/conjur-authn-k8s-client/issues/196)
    - RH base image is now ubi8/ubi instead of rhel7/rhel.
[cyberark/conjur-authn-k8s-client#324](https://github.com/cyberark/conjur-authn-k8s-client/pull/324)
* **Fixed**
    - Fixes bug in error handling within the VerifyFileExists method that resulted in a
panic when the error from os.Stat was not ErrNotExist. The fix includes introducing
the CAKC058 error and log message for a file permissions error and theCAKC059 error
and log message for when the path to a file exists but is not a regular file.
[cyberark/conjur-authn-k8s-client#252](https://github.com/cyberark/conjur-authn-k8s-client/issues/252)
#### [v0.21.0](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.21.0) (2021-06-25)
* **Added**
    - Introduces the conjur-config-cluster-prep and conjur-config-namespace-prep Helm charts.
Together these charts simplify the deployment of Conjur-authenticated applications as part of
the [Simplified Client Configuration](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/design/simple-client-configuration.md) feature.
[cyberark/conjur-authn-k8s-client#232](https://github.com/cyberark/conjur-authn-k8s-client/issues/232)
[cyberark/conjur-authn-k8s-client#249](https://github.com/cyberark/conjur-authn-k8s-client/issues/249)