### PR TITLE
Update suite.yml for v1.13.0+suite.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.13.0+suite.1] - 2021-08-13
+
 ## [v1.11.7+suite.1] - 2021-07-07
 
 ## [v1.11.6+suite.1] - 2021-05-11

--- a/suite.yml
+++ b/suite.yml
@@ -11,7 +11,7 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.11.7
+        version: v1.13.0
       - name: cyberark/conjur-openapi-spec
         url: https://github.com/cyberark/conjur-openapi-spec
         description: Conjur OpenAPI v3 specification
@@ -28,7 +28,7 @@ section:
       - name: cyberark/conjur-cli
         url: https://github.com/cyberark/conjur-cli
         description: Conjur Ruby CLI
-        version: v6.2.3
+        version: v6.2.4
       - name: cyberark/conjur-api-dotnet
         url: https://github.com/cyberark/conjur-api-dotnet
         description: Conjur .Net Client Library
@@ -63,7 +63,7 @@ section:
         url: https://github.com/cyberark/conjur-service-broker
         description: The Conjur Service Broker provides your applications running
           in Cloud Foundry with a Conjur identity.
-        version: v1.1.5
+        version: v1.2.1
       - name: cyberark/conjur-authn-k8s-client
         url: https://github.com/cyberark/conjur-authn-k8s-client
         tool: Kubernetes
@@ -76,7 +76,7 @@ section:
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        version: v1.1.3
+        version: v1.1.4
 
   - name: DevOps Tools
     description: Conjur OSS integrations with DevOps tools.
@@ -108,7 +108,7 @@ section:
         tool: Terraform
         description: Terraform provider that makes secrets in Conjur available in
           Terraform manifests.
-        version: v0.5.0
+        version: v0.6.0
 
   - name: Secretless Broker
     description: Secure your apps by making them Secretless.
@@ -118,7 +118,7 @@ section:
         description: Secretless Broker can be used to securely connect your
           applications to services they need - without ever having to fetch or
           manage passwords and keys.
-        version: v1.7.3
+        version: v1.7.5
 
   - name: Summon
     description: Run your processes wrapped with Summon to ensure they have
@@ -128,8 +128,8 @@ section:
         url: https://github.com/cyberark/summon
         description: Summon is a secure tool to inject secrets into a subprocess
           environment.
-        version: v0.8.4
+        version: v0.9.0
       - name: cyberark/summon-conjur
         url: https://github.com/cyberark/summon-conjur
         description: Summon provider for Conjur.
-        version: v0.5.4
+        version: v0.6.0


### PR DESCRIPTION
# Release Notes
All notable changes to this project will be documented in this file.

## [v1.13.0+suite.1] - 2021-08-13

## Table of Contents

- [Components](#components)
- [Installation Instructions for the Suite Release Version of Conjur](#installation-instructions-for-the-suite-release-version-of-conjur)
- [Upgrade Instructions](#upgrade-instructions)
- [Changes](#changes)

## Components

These are the components that combine to create this Conjur OSS Suite release and links
to their releases:

### Conjur Server
- **[cyberark/conjur v1.13.0](https://github.com/cyberark/conjur/releases/tag/v1.13.0)** (2021-07-29)
- **[cyberark/conjur-openapi-spec v5.1.1](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.1.1)** (2021-04-28)
- **[cyberark/conjur-oss-helm-chart v2.0.4](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.4)** (2021-04-12)

### Conjur SDK
- **[cyberark/conjur-cli v6.2.3](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.3)** (2020-12-22)
- **[cyberark/conjur-api-dotnet v2.0.0](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.0.0)** (2020-06-10)
- **[cyberark/conjur-api-go v0.7.1](https://github.com/cyberark/conjur-api-go/releases/tag/v0.7.1)** (2021-03-01)
- **[cyberark/conjur-api-java v3.0.2](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.2)** (2020-10-28)
- **[cyberark/conjur-api-python3 v7.0.1](https://github.com/cyberark/conjur-api-python3/releases/tag/v7.0.1)** (2020-04-12)
- **[cyberark/conjur-api-ruby v5.3.5](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.3.5)** (2021-05-04)

### Platform Integrations
- **[cyberark/cloudfoundry-conjur-buildpack v2.2.1](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.1)** (2020-06-24)
- **[cyberark/conjur-service-broker v1.2.1](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.1)** (2021-08-02)
- **[cyberark/conjur-authn-k8s-client v0.21.0](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.21.0)** (2021-06-25)
- **[cyberark/secrets-provider-for-k8s v1.1.4](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.1.4)** (2021-06-30)

### DevOps Tools
- **[cyberark/ansible-conjur-collection v1.1.0](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.1.0)** (2020-12-29)
- **[cyberark/ansible-conjur-host-identity v0.3.2](https://github.com/cyberark/ansible-conjur-host-identity/releases/tag/v0.3.2)** (2020-12-29)
- **[cyberark/conjur-puppet v3.1.0](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.0)** (2020-10-08)
- **[cyberark/terraform-provider-conjur v0.6.0](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.0)** (2021-08-12)

### Secretless Broker
- **[cyberark/secretless-broker v1.7.5](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.5)** (2021-08-04)

### Summon
- **[cyberark/summon v0.9.0](https://github.com/cyberark/summon/releases/tag/v0.9.0)** (2021-07-19)
- **[cyberark/summon-conjur v0.6.0](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.0)** (2021-08-11)

## Installation Instructions for the Suite Release Version of Conjur

Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.

+ **Docker or docker-compose**

  Set the container image tag to `cyberark/conjur:1.13.0`.
  For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
  ```
  image: cyberark/conjur:1.13.0
  ```

+ [**Conjur OSS Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

  Update the `image.tag` value and use the appropriate release of the helm chart:
  ```
  helm install ... \
    --set image.tag="1.13.0" \
    ...
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v2.0.4/conjur-oss-2.0.4.tgz
  ```

## Upgrade Instructions

Upgrade instructions are available for the following components:
- [cyberark/conjur](https://github.com/cyberark/conjur/blob/master/UPGRADING.md)
- [cyberark/conjur-oss-helm-chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)

## Changes
The following are changes to the constituent components since the last Conjur
OSS Suite release:
- ### [cyberark/conjur](#cyberarkconjur)
- ### [cyberark/conjur-cli](#cyberarkconjur-cli)
- ### [cyberark/conjur-service-broker](#cyberarkconjur-service-broker)
- ### [cyberark/secrets-provider-for-k8s](#cyberarksecrets-provider-for-k8s)
- ### [cyberark/terraform-provider-conjur](#cyberarkterraform-provider-conjur)
- ### [cyberark/secretless-broker](#cyberarksecretless-broker)
- ### [cyberark/summon](#cyberark/summon)
- ### [cyberark/summon-conjur](#cyberark/summon-conjur)

### cyberark/conjur

#### Added
- The JWT Authenticator (authn-jwt) supports authenticating third-party vendors that utilize JWT.
See [design](https://github.com/cyberark/conjur/blob/master/design/authenticators/authn_jwt/authn_jwt_solution_design.md)
- Set MAX_REQUESTS_PER_CONNECTION to infinity and introduced an
environment variable to allow users to set their own value,
see PR for further information:
[cyberark/conjur#2282](https://github.com/cyberark/conjur/issues/2282)
- Added enforced claims support to JWT generic vendor configuration. [ONYX-10520](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-10520)
- Added claims mapping support to JWT generic vendor configuration. [ONYX-10850](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-10850)
- Added audience check to JWT generic vendor configuration. [ONYX-10512](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-10512)

#### Changed
- Parsing a Conjur config with invalid YAML content now outputs a more user
friendly error message without a stack trace.
[cyberark/conjur#2256](https://github.com/cyberark/conjur/issues/2256)
- Set the Puma process explicitly to reliably restart the correct process
when the Conjur configuration is reloaded.
[cyberark/conjur#2291](https://github.com/cyberark/conjur/pull/2291)

#### Security
- Upgrade bindata to 2.4.10 to resolve Unspecified Issue reported by JFrog Xray
[cyberark/conjur#2257](https://github.com/cyberark/conjur/issues/2257)
- Bump cyberark/ubi-ruby-fips from 1.0.3 to 1.0.4 to address CVE-2021-33910.
[cyberark/conjur#2333](https://github.com/cyberark/conjur/issues/2333)
- Upgraded addressable in ./Gemfile.lock and ./docs/Gemfile.lock to 2.8.0 to resolve
GHSA-jxhc-q857-3j6g [cyberark/conjur#2311](https://github.com/cyberark/conjur/pull/2311)
- Previously, OIDC authentication requests that included a user ID in the URL
path would return a Conjur access token without requiring a valid OIDC token
in the request. OIDC authentication requests that attempt to include a user ID
in the URL path now return a 404 Not Found response.
[Security Bulletin](https://github.com/cyberark/conjur/security/advisories/GHSA-6xj8-59gr-4jp3)

### cyberark/conjur-cli

#### Changed
- Upgraded conjur-api dependency to 5.3.5.
[cyberark/conjur-cli#310](https://github.com/cyberark/conjur-cli/issues/310)

### cyberark/conjur-service-broker

#### Added
- Service Broker API spec 2.15 and above provide organization_name and space_name.
If these are available, they are added as annotations on the organization and space policies
that are created in Conjur. Note that this requires Conjur Open Source v1.3.7+ and Conjur
Enterprise (formerly Dynamic Access Provider) v11.3.0+; prior to these versions, Conjur
did not support adding annotations to policy resources.
[cyberark/conjur-service-broker#238](https://github.com/cyberark/conjur-service-broker/issues/238)

#### Fixed
- The service broker's ./manifest.yml now explicitly specifies a pinned version of the Ruby Buildpack,
[ruby-buildpack.git#v1.8.37](https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.37),
to ensure the pinned Ruby version in the Gemfile is available when the the service broker is deployed
onto TAS foundation.
[cyberark/conjur-service-broker#254](https://github.com/cyberark/conjur-service-broker/issues/254)

#### Security
- Updated addressable to 2.8.0 to resolve GHSA-jxhc-q857-3j6g
[cyberark/conjur-service-broker#251](https://github.com/cyberark/conjur-service-broker/pull/251)
- Updated puma to 5.3.1 to resolve GHSA-q28m-8xjw-8vr5
[cyberark/conjur-service-broker#246](https://github.com/cyberark/conjur-service-broker/issues/246)
- Updated nokogiri to 1.11.5 to resolve GHSA-7rrm-v45f-jp64
[cyberark/conjur-service-broker#246](https://github.com/cyberark/conjur-service-broker/issues/246)
- Updated rails packages (activesupport, railties, actionview) to 5.2.4.6 to resolve CVE-2021-22885
[cyberark/conjur-service-broker#241](https://github.com/cyberark/conjur-service-broker/issues/241)

### cyberark/secrets-provider-for-k8s

#### Changed
- Update RH base image to ubi8/ubi instead of rhel7/rhel.
[PR cyberark/secrets-provider-for-k8s#328](https://github.com/cyberark/secrets-provider-for-k8s/pull/328)

### cyberark/terraform-provider-conjur

#### Added
- Build for Apple M1 silicon.
[cyberark/terraform-provider-conjur#84](https://github.com/cyberark/terraform-provider-conjur/issues/84)

### cyberark/secretless-broker

#### Changed
- Update RH base image to ubi8/ubi instead of rhel7/rhel.
[PR cyberark/secretless-broker#1411](https://github.com/cyberark/secretless-broker/pull/1411)

#### Security
- Updated addressable to 2.8.0 in docs/Gemfile.lock to resolve GHSA-jxhc-q857-3j6g
[cyberark/secretless-broker#1418](https://github.com/cyberark/secretless-broker/pull/1418)
- Updated github.com/gogo/protobuf to 1.3.2 to resolve CVE-2021-3121
[cyberark/secretless-broker#1418](https://github.com/cyberark/secretless-broker/pull/1418)

### cyberark/summon

#### Added
- Build for Apple M1 silicon.
[cyberark/summon#216](https://github.com/cyberark/summon/issues/216)

#### Fixed
- Default provider path can be overridden via the SUMMON_PROVIDER_PATH environment variable,
resolving an issue where providers cannot be found when installed via homebrew in a non-default location.
[cyberark/summon#213](https://github.com/cyberark/summon/issues/213)

### cyberark/summon-conjur

#### Added
- Build for Apple M1 silicon.
[cyberark/summon-conjur#88](https://github.com/cyberark/summon-conjur/issues/88)

#### Security
- Update golang.org/x/crypto to address CVE-2020-29652.
[PR cyberark/summon-conjur#84](https://github.com/cyberark/summon-conjur/pull/84)