### PR TITLE
Update suite.yml for v1.13.1+suite.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.13.1+suite.1] - 2021-09-14
+
 ## [v1.13.0+suite.1] - 2021-08-13
 
 ## [v1.11.7+suite.1] - 2021-07-07
@@ -60,7 +62,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   open in a new window, unless the link points to a CyberArk docs site.
   [cyberark/conjur-oss-suite-release#199](https://github.com/cyberark/conjur-oss-suite-release/issues/199)
 
-[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.11.7+suite.1...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.13.1+suite.1...HEAD
+[v1.13.1+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.13.0+suite.1...v1.13.1+suite.1
+[v1.13.0+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.7+suite.1...v1.13.0+suite.1
 [v1.11.7+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.6+suite.1...v1.11.7+suite.1
 [v1.11.6+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.5+suite.1...v1.11.6+suite.1
 [v1.11.5+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.3+suite.1...v1.11.5+suite.1

--- a/suite.yml
+++ b/suite.yml
@@ -11,11 +11,11 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.13.0
+        version: v1.13.1
       - name: cyberark/conjur-openapi-spec
         url: https://github.com/cyberark/conjur-openapi-spec
         description: Conjur OpenAPI v3 specification
-        version: v5.1.1
+        version: v5.2.0
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
@@ -32,11 +32,11 @@ section:
       - name: cyberark/conjur-api-dotnet
         url: https://github.com/cyberark/conjur-api-dotnet
         description: Conjur .Net Client Library
-        version: v2.0.0
+        version: v2.1.0
       - name: cyberark/conjur-api-go
         url: https://github.com/cyberark/conjur-api-go
         description: Conjur Golang Client Library
-        version: v0.7.1
+        version: v0.8.0
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
@@ -69,14 +69,14 @@ section:
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        version: v0.21.0
+        version: v0.22.0
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
         tool: Kubernetes
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        version: v1.1.4
+        version: v1.1.5
 
   - name: DevOps Tools
     description: Conjur OSS integrations with DevOps tools.
@@ -108,7 +108,7 @@ section:
         tool: Terraform
         description: Terraform provider that makes secrets in Conjur available in
           Terraform manifests.
-        version: v0.6.0
+        version: v0.6.2
 
   - name: Secretless Broker
     description: Secure your apps by making them Secretless.
@@ -118,7 +118,7 @@ section:
         description: Secretless Broker can be used to securely connect your
           applications to services they need - without ever having to fetch or
           manage passwords and keys.
-        version: v1.7.5
+        version: v1.7.6
 
   - name: Summon
     description: Run your processes wrapped with Summon to ensure they have


### PR DESCRIPTION
# Release Notes
All notable changes to this project will be documented in this file.

## [v1.13.1+suite.1] - 2021-09-14

## Table of Contents

- [Components](#components)
- [Installation Instructions for the Suite Release Version of Conjur](#installation-instructions-for-the-suite-release-version-of-conjur)
- [Upgrade Instructions](#upgrade-instructions)
- [Changes](#changes)

## Components

These are the components that combine to create this Conjur OSS Suite release and links
to their releases:

### Conjur Server
- **[cyberark/conjur v1.13.1](https://github.com/cyberark/conjur/releases/tag/v1.13.1)** (2021-09-13) 
- **[cyberark/conjur-openapi-spec v5.2.0](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.2.0)** (2021-09-08) 
- **[cyberark/conjur-oss-helm-chart v2.0.4](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.4)** (2021-04-12) 

### Conjur SDK
- **[cyberark/conjur-cli v6.2.4](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.4)** (2021-07-01) 
- **[cyberark/conjur-api-dotnet v2.1.0](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.1.0)** (2021-09-08) 
- **[cyberark/conjur-api-go v0.8.0](https://github.com/cyberark/conjur-api-go/releases/tag/v0.8.0)** (2021-09-10) 
- **[cyberark/conjur-api-java v3.0.2](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.2)** (2020-10-28) 
- **[cyberark/conjur-api-python3 v7.0.1](https://github.com/cyberark/conjur-api-python3/releases/tag/v7.0.1)** (2020-04-12) 
- **[cyberark/conjur-api-ruby v5.3.5](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.3.5)** (2021-05-04) 

### Platform Integrations
- **[cyberark/cloudfoundry-conjur-buildpack v2.2.1](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.1)** (2020-06-24) 
- **[cyberark/conjur-service-broker v1.2.1](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.1)** (2021-08-02) 
- **[cyberark/conjur-authn-k8s-client v0.21.1](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.21.1)** (2021-09-09) 
- **[cyberark/secrets-provider-for-k8s v1.1.5](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.1.5)** (2021-08-13) 

### DevOps Tools
- **[cyberark/ansible-conjur-collection v1.1.0](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.1.0)** (2020-12-29) 
- **[cyberark/ansible-conjur-host-identity v0.3.2](https://github.com/cyberark/ansible-conjur-host-identity/releases/tag/v0.3.2)** (2020-12-29) 
- **[cyberark/conjur-puppet v3.1.0](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.0)** (2020-10-08) 
- **[cyberark/terraform-provider-conjur v0.6.2](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.2)** () 

### Secretless Broker
- **[cyberark/secretless-broker v1.7.6](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.6)** (2021-09-10) 

### Summon
- **[cyberark/summon v0.9.0](https://github.com/cyberark/summon/releases/tag/v0.9.0)** (2021-07-19) 
- **[cyberark/summon-conjur v0.6.0](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.0)** (2021-08-11) 

## Installation Instructions for the Suite Release Version of Conjur

Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.

+ **Docker or docker-compose**

  Set the container image tag to `cyberark/conjur:1.13.1`.
  For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
  ```
  image: cyberark/conjur:1.13.1
  ```

+ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

  Update the `image.tag` value and use the appropriate release of the helm chart:
  ```
  helm install ... \
    --set image.tag="1.13.1" \
    ...
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v2.0.4/conjur-oss-2.0.4.tgz
  ```

## Upgrade Instructions

Upgrade instructions are available for the following components:
- [cyberark/conjur](https://github.com/cyberark/conjur/blob/master/UPGRADING.md)
- [cyberark/conjur-oss-helm-chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)

## Changes
The following are changes to the constituent components since the last Conjur
OSS Suite release:
- [cyberark/conjur](#cyberarkconjur)
- [cyberark/conjur-openapi-spec](#cyberarkconjur-openapi-spec)
- [cyberark/conjur-api-dotnet](#cyberarkconjur-api-dotnet)
- [cyberark/conjur-api-go](#cyberarkconjur-api-go)
- [cyberark/conjur-authn-k8s-client](#cyberarkconjur-authn-k8s-client)
- [cyberark/secrets-provider-for-k8s](#cyberarksecrets-provider-for-k8s)
- [cyberark/terraform-provider-conjur](#cyberarkterraform-provider-conjur)
- [cyberark/secretless-broker](#cyberarksecretless-broker)

### cyberark/conjur

#### [v1.13.1](https://github.com/cyberark/conjur/releases/tag/v1.13.1) (2021-09-13)
* **Changed**
    - OIDC based authenticators no longer return Bad Gateway and Gateway Timeout http error codes.
Unauthorised is returned instead.
[cyberark/conjur#2360](https://github.com/cyberark/conjur/pull/2360)
* **Fixed**
    - Fix bug of cache not working in authn jwt. [cyberark/conjur#2353](https://github.com/cyberark/conjur/pull/2353)
    - Fix bug authn-jwt now appears in installed authenticators list of authenticators endpoint output. [cyberark/conjur#2365](https://github.com/cyberark/conjur/pull/2365)

### cyberark/conjur-openapi-spec

#### [v5.2.0](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.2.0) (2021-09-08)
* **Added**
    - New JWT authenticator endpoints have been added to the spec.
[cyberark/conjur-openapi-spec#193](https://github.com/cyberark/conjur-openapi-spec/pull/193)
* **Changed**
    - Consolidate bin/integration_test and bin/test_enterprise into bin/test_integration.
Renamed bin/api_test to bin/test_api_contract and bin/start to bin/dev to maintain
repository- and company-wide script convention.
[cyberark/conjur-openapi-spec#166](https://github.com/cyberark/conjur-openapi-spec/issues/166)
    - Remove Bad Gateway error code from authn-oidc error codes following [cyberark/conjur#2360](https://github.com/cyberark/conjur/pull/2360)
[cyberark/conjur-openapi-spec#204](https://github.com/cyberark/conjur-openapi-spec/pull/204)
* **Fixed**
    - Request body details for secret creation so all clients can properly set secrets. This changes
the MIME type of the request body to application/octet-stream in place of text plain,
allowing for proper binary secrets in clients (format: binary is broken in some clients).
[cyberark/conjur-openapi-spec#187](https://github.com/cyberark/conjur-openapi-spec/pull/187)
    - Authentication methods not requiring any API authentication (conjurAuth, basicAuth, etc) now
specify an empty list as the security field ensuring utilities dont assume all authentication
types are valid.
[cyberark/conjur-openapi-spec#196](https://github.com/cyberark/conjur-openapi-spec/pull/196)

### cyberark/conjur-api-dotnet

#### [v2.1.0](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.1.0) (2021-09-08)
* **Added**
    - Add parameter to the function Policy::LoadPolicy() to allow a different load method other than POST. POST being the default value. Currently Conjur supports POST, PUT and PATCH

### cyberark/conjur-api-go

#### [v0.8.0](https://github.com/cyberark/conjur-api-go/releases/tag/v0.8.0) (2021-09-10)
* **Added**
    - New check in RetrieveBatchSecretSafe method which will return an error if the Content-Type header
is not set in the response (this indicates Conjur is out of date with the client).
[cyberark/conjur-api-go#104](https://github.com/cyberark/conjur-api-go/issues/104)
* **Changed**
    - RetrieveBatchSecretsSafe method is updated to use the Accept-Encoding header
instead of Accept, consistent with [recent updates on the Conjur server](https://github.com/cyberark/conjur/pull/2065).
[cyberark/conjur-api-go#99](https://github.com/cyberark/conjur-api-go/issues/99)

### cyberark/conjur-authn-k8s-client

#### [v0.21.1](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.21.1) (2021-09-09)
* **Security**
    - Upgrades Openssl in Alpine to resolve CVE-2021-3711.
[cyberark/conjur-authn-k8s-client#392](https://github.com/cyberark/conjur-authn-k8s-client/issues/392)
    - Upgrades Alpine to v3.14 to resolve CVE-2021-36159.
[cyberark/conjur-authn-k8s-client#374](https://github.com/cyberark/conjur-authn-k8s-client/issues/374)

### cyberark/secrets-provider-for-k8s

#### [v1.1.5](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.1.5) (2021-08-13)
* **Added**
    - Adds Helm chart option to use an independently installed Conjur Connect
ConfigMap instead of configuring Conjur connection parameters via environment
variables.
[cyberark/secrets-provider-for-k8s#349](https://github.com/cyberark/secrets-provider-for-k8s/pull/349)
    - Adds Helm chart option to explicitly set the Secrets Provider Job name.
[cyberark/secrets-provider-for-k8s#352](https://github.com/cyberark/secrets-provider-for-k8s/pull/352)
* **Security**
    - Upgrades base Alpine image used for Secrets Provider container image to
v3.14 to resolve CVE-2021-36159.
[cyberark/secrets-provider-for-k8s#354](https://github.com/cyberark/secrets-provider-for-k8s/pull/354)

### cyberark/terraform-provider-conjur

#### [v0.6.1](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.1) (2021-09-02)
* **Changed**
    - Archive format changed to support publishing to registry.terraform.io

### cyberark/secretless-broker

#### [v1.7.6](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.6) (2021-09-10)
* **Added**
    - Secretless and secretless-redhat containers now use Alpine 3.14 as their base
image. [PR cyberark/secretless-broker#1423](https://github.com/cyberark/secretless-broker/pull/1423)
