### PR TITLE
Bump version for v1.14.1+suite.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.14.1+suite.1] - 2021-11-12
+
 ## [v1.13.1+suite.1] - 2021-09-14
 
 ## [v1.13.0+suite.1] - 2021-08-13
@@ -62,7 +64,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   open in a new window, unless the link points to a CyberArk docs site.
   [cyberark/conjur-oss-suite-release#199](https://github.com/cyberark/conjur-oss-suite-release/issues/199)
 
-[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.13.1+suite.1...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.14.1+suite.1...HEAD
+[v1.14.1+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.13.1+suite.1...v1.14.1+suite.1
 [v1.13.1+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.13.0+suite.1...v1.13.1+suite.1
 [v1.13.0+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.7+suite.1...v1.13.0+suite.1
 [v1.11.7+suite.1]: https://github.com/cyberark/conjur-oss-helm-chart/compare/v1.11.6+suite.1...v1.11.7+suite.1

--- a/suite.yml
+++ b/suite.yml
@@ -11,7 +11,7 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.13.1
+        version: v1.14.1
       - name: cyberark/conjur-openapi-spec
         url: https://github.com/cyberark/conjur-openapi-spec
         description: Conjur OpenAPI v3 specification
@@ -28,7 +28,7 @@ section:
       - name: cyberark/conjur-cli
         url: https://github.com/cyberark/conjur-cli
         description: Conjur Ruby CLI
-        version: v6.2.4
+        version: v6.2.5
       - name: cyberark/conjur-api-dotnet
         url: https://github.com/cyberark/conjur-api-dotnet
         description: Conjur .Net Client Library
@@ -76,7 +76,7 @@ section:
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        version: v1.1.5
+        version: v1.1.6
 
   - name: DevOps Tools
     description: Conjur OSS integrations with DevOps tools.
@@ -118,7 +118,7 @@ section:
         description: Secretless Broker can be used to securely connect your
           applications to services they need - without ever having to fetch or
           manage passwords and keys.
-        version: v1.7.6
+        version: v1.7.8
 
   - name: Summon
     description: Run your processes wrapped with Summon to ensure they have


### PR DESCRIPTION
# Release Notes
All notable changes to this project will be documented in this file.

## [1.14.1+suite.1] - 2021-11-12

## Table of Contents

- [Components](#components)
- [Installation Instructions for the Suite Release Version of Conjur](#installation-instructions-for-the-suite-release-version-of-conjur)
- [Upgrade Instructions](#upgrade-instructions)
- [Changes](#changes)

## Components

These are the components that combine to create this Conjur OSS Suite release and links
to their releases:

### Conjur Server
- **[cyberark/conjur v1.14.1](https://github.com/cyberark/conjur/releases/tag/v1.14.1)** (2021-11-05) 
- **[cyberark/conjur-openapi-spec v5.2.0](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.2.0)** (2021-09-08) 
- **[cyberark/conjur-oss-helm-chart v2.0.4](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.4)** (2021-04-12) 

### Conjur SDK
- **[cyberark/conjur-cli v6.2.5](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.5)** (2021-09-29) 
- **[cyberark/conjur-api-dotnet v2.1.0](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.1.0)** (2021-09-08) 
- **[cyberark/conjur-api-go v0.8.0](https://github.com/cyberark/conjur-api-go/releases/tag/v0.8.0)** (2021-09-10) 
- **[cyberark/conjur-api-java v3.0.2](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.2)** (2020-10-28) 
- **[cyberark/conjur-api-python3 v7.0.1](https://github.com/cyberark/conjur-api-python3/releases/tag/v7.0.1)** (2020-04-12) 
- **[cyberark/conjur-api-ruby v5.3.5](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.3.5)** (2021-05-04) 

### Platform Integrations
- **[cyberark/cloudfoundry-conjur-buildpack v2.2.1](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.1)** (2020-06-24) 
- **[cyberark/conjur-service-broker v1.2.1](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.1)** (2021-08-02) 
- **[cyberark/conjur-authn-k8s-client v0.21.1](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.21.1)** (2021-09-09) 
- **[cyberark/secrets-provider-for-k8s v1.1.6](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.1.6)** (2021-10-31) 

### DevOps Tools
- **[cyberark/ansible-conjur-collection v1.1.0](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.1.0)** (2020-12-29) 
- **[cyberark/ansible-conjur-host-identity v0.3.2](https://github.com/cyberark/ansible-conjur-host-identity/releases/tag/v0.3.2)** (2020-12-29) 
- **[cyberark/conjur-puppet v3.1.0](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.0)** (2020-10-08) 
- **[cyberark/terraform-provider-conjur v0.6.2](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.2)** () 

### Secretless Broker
- **[cyberark/secretless-broker v1.7.8](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.8)** (2021-11-09) 

### Summon
- **[cyberark/summon v0.9.0](https://github.com/cyberark/summon/releases/tag/v0.9.0)** (2021-07-19) 
- **[cyberark/summon-conjur v0.6.0](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.0)** (2021-08-11) 

## Installation Instructions for the Suite Release Version of Conjur

Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.

+ **Docker or docker-compose**

  Set the container image tag to `cyberark/conjur:1.14.1`.
  For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
  ```
  image: cyberark/conjur:1.14.1
  ```

+ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

  Update the `image.tag` value and use the appropriate release of the helm chart:
  ```
  helm install ... \
    --set image.tag="1.14.1" \
    ...
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v2.0.4/conjur-oss-2.0.4.tgz
  ```

## Upgrade Instructions

Upgrade instructions are available for the following components:
- [cyberark/conjur](https://github.com/cyberark/conjur/blob/master/UPGRADING.md)
- [cyberark/conjur-oss-helm-chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)

## Changes
The following are changes to the constituent components since the last Conjur
OSS Suite release:
- [cyberark/conjur](#cyberarkconjur)
- [cyberark/conjur-openapi-spec](#cyberarkconjur-openapi-spec)
- [cyberark/conjur-api-dotnet](#cyberarkconjur-api-dotnet)
- [cyberark/conjur-api-go](#cyberarkconjur-api-go)
- [cyberark/conjur-authn-k8s-client](#cyberarkconjur-authn-k8s-client)
- [cyberark/secrets-provider-for-k8s](#cyberarksecrets-provider-for-k8s)
- [cyberark/terraform-provider-conjur](#cyberarkterraform-provider-conjur)
- [cyberark/secretless-broker](#cyberarksecretless-broker)

### cyberark/conjur

#### [v1.14.1](https://github.com/cyberark/conjur/releases/tag/v1.14.1) (2021-11-05)
* **Fixed**
    - Version bump to resolve build error on tagged master. [#2416](https://github.com/cyberark/conjur/pull/2416)

#### [v1.14.0](https://github.com/cyberark/conjur/releases/tag/v1.14.0) (2021-11-04)
* **Added**
    - Create default account when no account is specified in `conjurctl account create`.
[cyberark/conjur#2388](https://github.com/cyberark/conjur/pull/2388)
    - JWT Authenticator supports nested claims in `token-app-property`, `enforced-claims`,
`claim-aliases` and role annotations. ([ONYX-11204](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-11204):
[#2397](https://github.com/cyberark/conjur/pull/2397),
[#2404](https://github.com/cyberark/conjur/pull/2404),
[#2403](https://github.com/cyberark/conjur/pull/2403))

* **Changed**
    - Changed claims mapping variable name ('mapping-claims' => 'claim-aliases').
[cyberark/conjur#2382](https://github.com/cyberark/conjur/pull/2382)

### cyberark/conjur-cli

#### [v6.2.5](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.5) (2021-09-29)
* **Fixed**
    - Upgraded `highline` dependency to fix deprecation warning.
[cyberark/conjur-cli#330](https://github.com/cyberark/conjur-cli/pull/330)

### cyberark/secrets-provider-for-k8s

#### [v1.1.6](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.1.6) (2021-10-31)
* **Added**
    - Adds support for Secrets Provider M1 Push-to-File feature, Community release.
[cyberark/secrets-provider-for-k8s#358](https://github.com/cyberark/secrets-provider-for-k8s/pull/358)
[cyberark/secrets-provider-for-k8s#359](https://github.com/cyberark/secrets-provider-for-k8s/pull/359)
[cyberark/secrets-provider-for-k8s#362](https://github.com/cyberark/secrets-provider-for-k8s/pull/362)
[cyberark/secrets-provider-for-k8s#363](https://github.com/cyberark/secrets-provider-for-k8s/pull/363)
[cyberark/secrets-provider-for-k8s#364](https://github.com/cyberark/secrets-provider-for-k8s/pull/364)
[cyberark/secrets-provider-for-k8s#366](https://github.com/cyberark/secrets-provider-for-k8s/pull/366)
[cyberark/secrets-provider-for-k8s#367](https://github.com/cyberark/secrets-provider-for-k8s/pull/367)
[cyberark/secrets-provider-for-k8s#368](https://github.com/cyberark/secrets-provider-for-k8s/pull/368)
[cyberark/secrets-provider-for-k8s#376](https://github.com/cyberark/secrets-provider-for-k8s/pull/376)
[cyberark/secrets-provider-for-k8s#377](https://github.com/cyberark/secrets-provider-for-k8s/pull/377)
[cyberark/secrets-provider-for-k8s#378](https://github.com/cyberark/secrets-provider-for-k8s/pull/378)
    - Support for OpenShift 4.8 has been added.
[cyberark/secrets-provider-for-k8s#360](https://github.com/cyberark/secrets-provider-for-k8s/pull/360)

### cyberark/secretless-broker

#### [v1.7.8](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.8) (2021-11-09)
* **Fixed**
    - Version bump to resolve flakey test on tagged master.
[cyberark/secretless-broker#1438](https://github.com/cyberark/secretless-broker/pull/1438)

#### [v1.7.7](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.7) (2021-11-03)
* **Fixed**
    - Request-signing on the AWS connector was updated to address a bug that was
causing failed integrity checks, where the request-signing by Secretless was
incorporating more headers than were used on the original request-signing. The
fix limits the headers used by Secretless to those used in the original
request. [cyberark/secretless-broker#1432](https://github.com/cyberark/secretless-broker/issues/1432)

* **Security**
    - Updated containerd to v1.4.11 to close CVE-2020-15257 (Not vulnerable)
[cyberark/secretless-broker#1431](https://github.com/cyberark/secretless-broker/pull/1431)