### PR TITLE
Log warning message when no Github API token is specified

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -97,9 +97,13 @@ func RunParser(options Options) error {
 	httpClient := http.NewClient()
 
 	githubAPIToken := options.APIToken
-	if githubAPIToken == "" {
+	if len(githubAPIToken) == 0 {
 		githubAPIToken = os.Getenv("GITHUB_TOKEN")
 	}
+	if len(githubAPIToken) == 0 {
+		log.ErrLogger.Printf("WARN: No Github API token specified (via %q flag or %q environment variable). This run might FAIL due to the API rate limit", "-p", "GITHUB_TOKEN")
+	}
+
 	httpClient.AuthToken = githubAPIToken
 
 	suiteCategories, err := github.CollectSuiteCategories(repoConfig, httpClient, options.Version)


### PR DESCRIPTION
### Desired Outcome

A warning serves the dual purpose of informing the user of the possibility of specifying the Github API token, and anticipating a likely failure mode

Example logs:
```
@doodlesbykumbi ➜ /workspaces/conjur-oss-suite-release (main ✗) $ ./parse-changelogs -v v1.14.1+suite.1 -t release -o RELEASE_NOTES.md
2021/11/15 21:10:19 Starting changelog parser...
2021/11/15 21:10:19 Parsing linked repositories...
2021/11/15 21:10:19 Reading suite.yml...
2021/11/15 21:10:19 Unmarshaling data...
2021/11/15 21:10:19 Releases dir: releases
2021/11/15 21:10:19 Using releases/suite_1.13.1+suite.1.yml as previous release for pinning
2021/11/15 21:10:19 Reading releases/suite_1.13.1+suite.1.yml...
2021/11/15 21:10:19 Unmarshaling data...
2021/11/15 21:10:19 Collecting changelogs...
2021/11/15 21:10:19 WARN: No Github API token specified (via "-p" flag or "GITHUB_TOKEN" environment variable). This run might FAIL due to the API rate limit
2021/11/15 21:10:19 Processing category: Conjur Server
2021/11/15 21:10:19 - Processing repo: cyberark/conjur
2021/11/15 21:10:19   Fetching https://api.github.com/repos/cyberark/conjur/releases...
2021/11/15 21:10:19 ERROR: code 403: https://api.github.com/repos/cyberark/conjur/releases: {"message":"API rate limit exceeded for 51.124.226.40. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
exit status 1
```

### Connected Issue/Story

Resolves -

CyberArk internal issue link: [ONYX-14071](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14071)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

N/A

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
