### PR TITLE
Update suite.yml for v1.14.2+suite.1 release

### DIFF
--- a/suite.yml
+++ b/suite.yml
@@ -11,7 +11,7 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.14.1
+        version: v1.14.2
       - name: cyberark/conjur-openapi-spec
         url: https://github.com/cyberark/conjur-openapi-spec
         description: Conjur OpenAPI v3 specification
@@ -63,7 +63,7 @@ section:
         url: https://github.com/cyberark/conjur-service-broker
         description: The Conjur Service Broker provides your applications running
           in Cloud Foundry with a Conjur identity.
-        version: v1.2.1
+        version: v1.2.2
       - name: cyberark/conjur-authn-k8s-client
         url: https://github.com/cyberark/conjur-authn-k8s-client
         tool: Kubernetes
@@ -76,7 +76,7 @@ section:
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        version: v1.1.6
+        version: v1.2.0
 
   - name: DevOps Tools
     description: Conjur OSS integrations with DevOps tools.


### PR DESCRIPTION
# Release Notes
All notable changes to this project will be documented in this file.

## [v1.14.2+suite.1] - 2021-12-14

## Table of Contents

- [Components](#components)
- [Installation Instructions for the Suite Release Version of Conjur](#installation-instructions-for-the-suite-release-version-of-conjur)
- [Upgrade Instructions](#upgrade-instructions)
- [Changes](#changes)

## Components

These are the components that combine to create this Conjur OSS Suite release and links
to their releases:

### Conjur Server
- **[cyberark/conjur v1.14.2](https://github.com/cyberark/conjur/releases/tag/v1.14.2)** (2021-12-13) 
- **[cyberark/conjur-openapi-spec v5.2.0](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.2.0)** (2021-09-08) 
- **[cyberark/conjur-oss-helm-chart v2.0.4](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.4)** (2021-04-12) 

### Conjur SDK
- **[cyberark/conjur-cli v6.2.5](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.5)** (2021-09-29) 
- **[cyberark/conjur-api-dotnet v2.1.0](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.1.0)** (2021-09-08) 
- **[cyberark/conjur-api-go v0.8.0](https://github.com/cyberark/conjur-api-go/releases/tag/v0.8.0)** (2021-09-10) 
- **[cyberark/conjur-api-java v3.0.2](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.2)** (2020-10-28) 
- **[cyberark/conjur-api-python3 v7.0.1](https://github.com/cyberark/conjur-api-python3/releases/tag/v7.0.1)** (2020-04-12) 
- **[cyberark/conjur-api-ruby v5.3.5](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.3.5)** (2021-05-04) 

### Platform Integrations
- **[cyberark/cloudfoundry-conjur-buildpack v2.2.1](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.1)** (2020-06-24) 
- **[cyberark/conjur-service-broker v1.2.2](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.2)** (2021-11-03) 
- **[cyberark/conjur-authn-k8s-client v0.22.0](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.22.0)** (2021-09-17) 
- **[cyberark/secrets-provider-for-k8s v1.2.0](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.2.0)** (2021-11-30) 

### DevOps Tools
- **[cyberark/ansible-conjur-collection v1.1.0](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.1.0)** (2020-12-29) 
- **[cyberark/ansible-conjur-host-identity v0.3.2](https://github.com/cyberark/ansible-conjur-host-identity/releases/tag/v0.3.2)** (2020-12-29) 
- **[cyberark/conjur-puppet v3.1.0](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.0)** (2020-10-08) 
- **[cyberark/terraform-provider-conjur v0.6.2](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.2)** (2021-09-02) 

### Secretless Broker
- **[cyberark/secretless-broker v1.7.8](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.8)** (2021-11-09) 

### Summon
- **[cyberark/summon v0.9.0](https://github.com/cyberark/summon/releases/tag/v0.9.0)** (2021-07-19) 
- **[cyberark/summon-conjur v0.6.0](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.0)** (2021-08-11) 

## Installation Instructions for the Suite Release Version of Conjur

Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.

+ **Docker or docker-compose**

  Set the container image tag to `cyberark/conjur:1.14.2`.
  For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
  ```
  image: cyberark/conjur:1.14.2
  ```

+ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

  Update the `image.tag` value and use the appropriate release of the helm chart:
  ```
  helm install ... \
    --set image.tag="1.14.2" \
    ...
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v2.0.4/conjur-oss-2.0.4.tgz
  ```

## Upgrade Instructions

Upgrade instructions are available for the following components:
- [cyberark/conjur](https://github.com/cyberark/conjur/blob/master/UPGRADING.md)
- [cyberark/conjur-oss-helm-chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)

## Changes
The following are changes to the constituent components since the last Conjur
OSS Suite release:
- [cyberark/conjur](#cyberarkconjur)
- [cyberark/conjur-service-broker](#cyberarkconjur-service-broker)
- [cyberark/secrets-provider-for-k8s](#cyberarksecrets-provider-for-k8s)

### cyberark/conjur

#### [v1.14.2](https://github.com/cyberark/conjur/releases/tag/v1.14.2) (2021-12-13)
* **Changed**
    - Failed Login now writes the error code in the log
[#2424](https://github.com/cyberark/conjur/pull/2424)
    - Bump cyberark base images from 1.0.5 to 1.0.6
[#2420](https://github.com/cyberark/conjur/pull/2420)
    - Bump cyberark base images from 1.0.4 to 1.0.5
[#2418](https://github.com/cyberark/conjur/pull/2418)
* **Fixed**
    - Return 401 instead of 500 for invalid basic auth header.
[#1990](https://github.com/cyberark/conjur/issues/1990)
    - Added check to stop hosts from setting passwords
[#1920](https://github/cyberark/conjur/issues/1920)
* **Security**
    - Bump gems related to openid_connect stack for improving the certificate
validation procedure during the OIDC keys discovery process
[cyberark/ONYX-13304](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-13304)

### cyberark/conjur-service-broker

#### [v1.2.2](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.2) (2021-11-03)
* **Security**
    - Updated Nokogiri to 1.12.5-x86_64-darwin to resolve
[CVE-2021-41098](https://github.com/advisories/GHSA-2rr5-8q37-2w7h)
[cyberark/conjur-service-broker#257](https://github.com/cyberark/conjur-service-broker/pull/257)

### cyberark/secrets-provider-for-k8s

#### [v1.2.0](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.2.0) (2021-11-30)
* **Added**
    - Adds validation for output filepaths and names in Push-to-File, requiring
valid Linux filenames that are unique across all secret groups.
[cyberark/secrets-provider-for-k8s#386](https://github.com/cyberark/secrets-provider-for-k8s/pull/386)
    - Adds support for Push-to-File annotation conjur.org/conjur-secrets-policy-path.{secret-group}.
[cyberark/secrets-provider-for-k8s#392](https://github.com/cyberark/secrets-provider-for-k8s/pull/392)
* **Changed**
    - Push-to-File supports more intuitive output filepaths. Filepaths are
no longer required to contain the hard-coded mount path /conjur/secrets, and
can specify intermediate directories.
[cyberark/secrets-provider-for-k8s#381](https://github.com/cyberark/secrets-provider-for-k8s/pull/381)
