### PR TITLE
Update suite.yml for v1.17.6+suite.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v1.17.6+suite.1] - 2022-05-17
+
 ### Changed
 - Updated go dependencies to latest versions (github.com/gomarkdown/markdown
   -> v0.0.0-20220607163217-45f7c050e2d1, github.com/stretchr/testify -> v1.7.2,
   gopkg.in/yaml.v3 -> v3.0.1)
   [cyberark/conjur-oss-suite-release#248](https://github.com/cyberark/conjur-oss-suite-release/pull/248)
 
-## [v1.17.6+suite.1] - 2022-05-17
 ### Security
 - Updated gopkg.in/yaml.v2 to resolve CVE-2019-11254
   [cyberark/conjur-oss-suite-release#245](https://github.com/cyberark/conjur-oss-suite-release/pull/245)
   [cyberark/conjur-oss-suite-release#246](https://github.com/cyberark/conjur-oss-suite-release/pull/246)
+
+## [v1.15.0+suite.1] - 2022-01-24
 
 ### Changed
 - Updated Go version to 1.17. [cyberark/conjur-oss-suite-release#241](https://github.com/cyberark/conjur-oss-suite-release/pull/241)

--- a/suite.yml
+++ b/suite.yml
@@ -11,11 +11,11 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.15.0
+        version: v1.17.6
       - name: cyberark/conjur-openapi-spec
         url: https://github.com/cyberark/conjur-openapi-spec
         description: Conjur OpenAPI v3 specification
-        version: v5.2.0
+        version: v5.3.0
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
@@ -32,15 +32,15 @@ section:
       - name: cyberark/conjur-api-dotnet
         url: https://github.com/cyberark/conjur-api-dotnet
         description: Conjur .Net Client Library
-        version: v2.1.0
+        version: v2.1.1
       - name: cyberark/conjur-api-go
         url: https://github.com/cyberark/conjur-api-go
         description: Conjur Golang Client Library
-        version: v0.8.0
+        version: v0.10.1
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
-        version: v3.0.2
+        version: v3.0.3
       - name: cyberark/conjur-api-python3
         url: https://github.com/cyberark/conjur-api-python3
         description: Conjur Python Client Library
@@ -48,7 +48,7 @@ section:
       - name: cyberark/conjur-api-ruby
         url: https://github.com/cyberark/conjur-api-ruby
         description: Conjur Ruby Client Library
-        version: v5.3.5
+        version: v5.3.7
 
   - name: Platform Integrations
     description: Tools for Conjur integrations with platforms and cloud providers.
@@ -58,25 +58,25 @@ section:
         description: The Conjur Buildpack will use the Conjur identity provided
           by the Conjur Service Broker to inject secrets into your application
           environment at runtime.
-        version: v2.2.1
+        version: v2.2.4
       - name: cyberark/conjur-service-broker
         url: https://github.com/cyberark/conjur-service-broker
         description: The Conjur Service Broker provides your applications running
           in Cloud Foundry with a Conjur identity.
-        version: v1.2.3
+        version: v1.2.5
       - name: cyberark/conjur-authn-k8s-client
         url: https://github.com/cyberark/conjur-authn-k8s-client
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        version: v0.22.0
+        version: v0.23.6
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
         tool: Kubernetes
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        version: v1.3.0
+        version: v1.4.3
 
   - name: DevOps Tools
     description: Conjur OSS integrations with DevOps tools.
@@ -118,7 +118,7 @@ section:
         description: Secretless Broker can be used to securely connect your
           applications to services they need - without ever having to fetch or
           manage passwords and keys.
-        version: v1.7.8
+        version: v1.7.13
 
   - name: Summon
     description: Run your processes wrapped with Summon to ensure they have
@@ -128,8 +128,8 @@ section:
         url: https://github.com/cyberark/summon
         description: Summon is a secure tool to inject secrets into a subprocess
           environment.
-        version: v0.9.0
+        version: v0.9.3
       - name: cyberark/summon-conjur
         url: https://github.com/cyberark/summon-conjur
         description: Summon provider for Conjur.
-        version: v0.6.0
+        version: v0.6.4


### PR DESCRIPTION
# Release Notes
All notable changes to this project will be documented in this file.

## [1.17.6-suite.1] - 2022-07-08

## Table of Contents

- [Components](#components)
- [Installation Instructions for the Suite Release Version of Conjur](#installation-instructions-for-the-suite-release-version-of-conjur)
- [Upgrade Instructions](#upgrade-instructions)
- [Changes](#changes)

## Components

These are the components that combine to create this Conjur OSS Suite release and links
to their releases:

### Conjur Server
- **[cyberark/conjur v1.17.6](https://github.com/cyberark/conjur/releases/tag/v1.17.6)** (2022-04-07) 
- **[cyberark/conjur-openapi-spec v5.3.0](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.3.0)** (2021-12-22) 
- **[cyberark/conjur-oss-helm-chart v2.0.4](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.4)** (2021-04-12) 

### Conjur SDK
- **[cyberark/conjur-cli v6.2.5](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.5)** (2021-09-29) 
- **[cyberark/conjur-api-dotnet v2.1.1](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.1.1)** (2022-03-14) 
- **[cyberark/conjur-api-go v0.10.1](https://github.com/cyberark/conjur-api-go/releases/tag/v0.10.1)** (2022-06-14) 
- **[cyberark/conjur-api-java v3.0.3](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.3)** (2022-05-31) 
- **[cyberark/conjur-api-python3 v7.1.0](https://github.com/cyberark/conjur-api-python3/releases/tag/v7.1.0)** (2021-12-22) 
- **[cyberark/conjur-api-ruby v5.3.7](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.3.7)** (2021-12-28) 

### Platform Integrations
- **[cyberark/cloudfoundry-conjur-buildpack v2.2.4](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.4)** (2022-06-16) 
- **[cyberark/conjur-service-broker v1.2.5](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.5)** (2022-06-16) 
- **[cyberark/conjur-authn-k8s-client v0.23.6](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.23.6)** (2022-06-16) 
- **[cyberark/secrets-provider-for-k8s v1.4.3](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.4.3)** (2022-07-07) 

### DevOps Tools
- **[cyberark/ansible-conjur-collection v1.1.0](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.1.0)** (2020-12-29) 
- **[cyberark/ansible-conjur-host-identity v0.3.2](https://github.com/cyberark/ansible-conjur-host-identity/releases/tag/v0.3.2)** (2020-12-29) 
- **[cyberark/conjur-puppet v3.1.0](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.0)** (2020-10-08) 
- **[cyberark/terraform-provider-conjur v0.6.2](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.2)** (2021-09-02) 

### Secretless Broker
- **[cyberark/secretless-broker v1.7.13](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.13)** (2022-07-07) 

### Summon
- **[cyberark/summon v0.9.3](https://github.com/cyberark/summon/releases/tag/v0.9.3)** (2022-06-15) 
- **[cyberark/summon-conjur v0.6.4](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.4)** (2022-07-06) 

## Installation Instructions for the Suite Release Version of Conjur

Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.

+ **Docker or docker-compose**

  Set the container image tag to `cyberark/conjur:1.17.6`.
  For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
  ```
  image: cyberark/conjur:1.17.6
  ```

+ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

  Update the `image.tag` value and use the appropriate release of the helm chart:
  ```
  helm install ... \
    --set image.tag="1.17.6" \
    ...
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v2.0.4/conjur-oss-2.0.4.tgz
  ```

## Upgrade Instructions

Upgrade instructions are available for the following components:
- [cyberark/conjur](https://github.com/cyberark/conjur/blob/master/UPGRADING.md)
- [cyberark/conjur-oss-helm-chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)

## Changes
The following are changes to the constituent components since the last Conjur
OSS Suite release:
- [cyberark/conjur](#cyberarkconjur)
- [cyberark/conjur-openapi-spec](#cyberarkconjur-openapi-spec)
- [cyberark/conjur-api-dotnet](#cyberarkconjur-api-dotnet)
- [cyberark/conjur-api-go](#cyberarkconjur-api-go)
- [cyberark/conjur-api-java](#cyberarkconjur-api-java)
- [cyberark/conjur-api-ruby](#cyberarkconjur-api-ruby)
- [cyberark/cloudfoundry-conjur-buildpack](#cyberarkcloudfoundry-conjur-buildpack)
- [cyberark/conjur-service-broker](#cyberarkconjur-service-broker)
- [cyberark/conjur-authn-k8s-client](#cyberarkconjur-authn-k8s-client)
- [cyberark/secrets-provider-for-k8s](#cyberarksecrets-provider-for-k8s)
- [cyberark/secretless-broker](#cyberarksecretless-broker)
- [cyberark/summon](#cyberarksummon)
- [cyberark/summon-conjur](#cyberarksummon-conjur)

### cyberark/conjur

#### [v1.17.3](https://github.com/cyberark/conjur/releases/tag/v1.17.3) (2022-04-04)
* **Changed**
    - Fixed issue where an invalid content type sent by our .NET SDK was causing
Conjur to error - but this wasn't the case before the Ruby 3 upgrade
[#2525](https://github.com/cyberark/conjur/pull/2525)
    - Verify non user or host resources do not have credentials.
    - Update to automated release process
    - Proper error message appears when JWT Authenticator gets HTTP code error while trying to fetch JWKS data from `jwks-uri` [#2474](https://github.com/cyberark/conjur/pull/2474)
    - Upgrade to Ruby 3. [#2444](https://github.com/cyberark/conjur/pull/2444)
* **Added**
    - Added the ability to fetch signing keys from JWKS endpoints that use a self-signed certificate or a certificate signed by a third-party CA for JWT generic vendor configuration
  ([#2462](https://github.com/cyberark/conjur/pull/2462) [#2461](https://github.com/cyberark/conjur/pull/2461) [#2456](https://github.com/cyberark/conjur/pull/2456) [#2455](https://github.com/cyberark/conjur/pull/2455) [#2457](https://github.com/cyberark/conjur/pull/2457) [#2452](https://github.com/cyberark/conjur/pull/2452) [#2437](https://github.com/cyberark/conjur/pull/2437))
    - Added the ability for JWT generic vendor configuration to receive signing keys for JWT token verification from a variable. Variable name is `public-keys`
  ([#2463](https://github.com/cyberark/conjur/pull/2463) [#2461](https://github.com/cyberark/conjur/pull/2461) [#2456](https://github.com/cyberark/conjur/pull/2456) [#2455](https://github.com/cyberark/conjur/pull/2455) [#2454](https://github.com/cyberark/conjur/pull/2454) [#2450](https://github.com/cyberark/conjur/pull/2450) [#2447](https://github.com/cyberark/conjur/pull/2447) [#2437](https://github.com/cyberark/conjur/pull/2437))
    - Added support for SNI certificates when talking to the Kubernetes API server through the web socket client.
  [#2482](https://github.com/cyberark/conjur/pull/2482)
    - Added support for http(s)_proxy for Kubernetes client in Kubernetes authenticator
  [#2432](https://github.com/cyberark/conjur/pull/2432)
* **Fixed**
    - IAM Authn bug fix - Take rexml gem to production configuration [#2493](https://github.com/cyberark/conjur/pull/2493)
    - Previously, a stale puma pid file would prevent the Conjur server from starting successfully. Conjur now removes a stale pid file at startup, if it exists. [#2498](https://github.com/cyberark/conjur/pull/2498)
    - Use entirety of configured Kubernetes endpoint URL in Kubernetes authenticator's web socket client, instead of only host and port [#2479](https://github.com/cyberark/conjur/pull/2479)
* **Security**
    - Updated rails to 6.1.4.7 to resolve CVE-2022-21831 (not vulnerable)
  [cyberark/conjur#2513](https://github.com/cyberark/conjur/pull/2513)
    - Updated nokogiri to 1.13.3 to resolve CVE-2022-23308 and CVE-2021-30560
  [cyberark/conjur#2504](https://github.com/cyberark/conjur/pull/2504)
    - Updated Rails to 6.1.4.4 to resolve CVE-2021-44528 (Medium, Not Vulnerable)
  [cyberark/conjur#2486](https://github.com/cyberark/conjur/pull/2486)
    - Updated Rails to 6.1.4.6 to resolve CVE-2022-23633
    - Updated Puma to 5.6.2 to resolve CVE-2022-23634
  [cyberark/conjur#2492](https://github.com/cyberark/conjur/pull/2492)
    - Updated Puma to 5.6.4 to resolve CVE-2022-24790
  [cyberark/conjur#2534](https://github.com/cyberark/conjur/pull/2534)
    - Updated KubeClient to 4.9.3 to resolve CVE-2022-0759
[cyberark/conjur#2527](https://github.com/cyberark/conjur/pull/2527)
#### [v1.17.6](https://github.com/cyberark/conjur/releases/tag/v1.17.6) (2022-04-07)
* **Changed**
    - Adds CONJUR_USERS_IN_ROOT_POLICY_ONLY environment variable to prevent users from being created outside the root policy.
    - Fixed promotion behavior
* **Security**
    - Upgrade Rails to 6.12.5.1 to close CVE-2022-22577 and CVE-2022-27777
[cyberark/conjur#2553](https://github.com/cyberark/conjur/pull/2553)
    - Updated nokogiri to 1.13.4 to resolve CVE-2022-24836
  [cyberark/conjur#2534](https://github.com/cyberark/conjur/pull/2534)

### cyberark/conjur-openapi-spec

#### [v5.3.0](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.3.0) (2021-12-22)
* **Added**
    - Add new route for enabling authenticator with default service
[cyberark/conjur-openapi-spec#215](https://github.com/cyberark/conjur-openapi-spec/pull/215)

### cyberark/conjur-api-dotnet

#### [v2.1.1](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.1.1) (2022-03-14)
* **Fixed**
    - Fix mime type "text/plain"
[cyberark/conjur-api-dotnet#82](https://github.com/cyberark/conjur-api-dotnet/pull/82)

### cyberark/conjur-api-go

#### [v0.8.1](https://github.com/cyberark/conjur-api-go/releases/tag/v0.8.1) (2021-12-16)
* **Changed**
    - Update Golang version to 1.17
[cyberark/conjur-api-go#121](https://github.com/cyberark/conjur-api-go/pull/121)
    - Update Golang version to 1.16.
[cyberark/conjur-api-go#117](https://github.com/cyberark/conjur-api-go/pull/117)
#### [v0.9.0](https://github.com/cyberark/conjur-api-go/releases/tag/v0.9.0) (2022-02-20)
* **Added**
    - New CONJUR_AUTHN_JWT_SERVICE_ID & JWT_TOKEN_PATH environment variables as configuration to support authn-jwt
[cyberark/conjur-api-go#124](https://github.com/cyberark/conjur-api-go/pull/124)
* **Changed**
    - Update Dockerfile to use Go 1.17 base image
[cyberark/conjur-api-go#126](https://github.com/cyberark/conjur-api-go/pull/126)
#### [v0.10.0](https://github.com/cyberark/conjur-api-go/releases/tag/v0.10.0) (2022-05-19)
* **Added**
    - New CONJUR_AUTHN_JWT_HOST_ID environment variable for authn-jwt [cyberark/conjur-api-go#130](https://github.com/cyberark/conjur-api-go/pull/130)
#### [v0.10.1](https://github.com/cyberark/conjur-api-go/releases/tag/v0.10.1) (2022-06-14)
* **Changed**
    - Update testify to 1.7.2
[cyberark/conjur-api-go#133](https://github.com/cyberark/conjur-api-go/pull/133)

### cyberark/conjur-api-java

#### [v3.0.3](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.3) (2022-05-31)
* **Security**
    - Upgraded OpenJDK Dockerfile base image to 17-jdk-bullseye.
[cyberark/conjur-api-java#107](https://github.com/cyberark/conjur-api-java/pull/107)
    - Upgraded nginx Dockerfile base image to fix CVE-2022-0778 and CVE-2022-1292.
[cyberark/conjur-api-java#111](https://github.com/cyberark/conjur-api-java/pull/111)

### cyberark/conjur-api-ruby

#### [v5.3.6](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.3.6) (2021-12-09)
* **Changed**
    - Support ruby-3.0.2.
[cyberark/conjur-api-ruby#197](https://github.com/cyberark/conjur-api-ruby/pull/197)
#### [v5.3.7](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.3.7) (2021-12-28)
* **Changed**
    - Change addressable gem dependency.
[cyberark/conjur-api-ruby#199](https://github.com/cyberark/conjur-api-ruby/pull/199)
    - Update to use automated release process

### cyberark/cloudfoundry-conjur-buildpack

#### [v2.2.2](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.2) (2022-01-03)
* **Changed**
    - Updated conjur-api-go to version 0.8.1
[cyberark/cloudfoundry-conjur-buildpack#131](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/131)
#### [v2.2.3](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.3) (2022-06-07)
* **Changed**
    - Project Go version bumped to 1.17, and support for deprecated Go versions
1.14.x and 1.15.x removed.
[cyberark/cloudfoundry-conjur-buildpack#137](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/137)
    - Updated conjur-api-go to version 0.10.0
[cyberark/cloudfoundry-conjur-buildpack#140](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/140)
* **Security**
    - Updated sinatra in ruby test app to 2.2.0
[cyberark/cloudfoundry-conjur-buildpack#135](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/135)
    - Golang-based Docker images bumped to version 1.17.9-stretch
[cyberark/cloudfoundry-conjur-buildpack#137](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/137)
#### [v2.2.4](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.4) (2022-06-16)
* **Changed**
    - Updated conjur-api-go to 0.10.1 and summon to 0.9.3 in conjur-env/go.mod
[cyberark/cloudfoundry-conjur-buildpack#145](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/145)
    - Updated Spring in tests/integration/apps/java to 2.7.0
[cyberark/cloudfoundry-conjur-buildpack#144](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/144)
    - Updated conjur-env dependencies to latest versions (github.com/cyberark/summon -> v0.9.2,
github.com/stretchr/testify -> v1.7.2)
[cyberark/cloudfoundry-conjur-buildpack#143](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/143)

### cyberark/conjur-service-broker

#### [v1.2.4](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.4) (2022-05-05)
* **Fixed**
    - Unpin the Ruby Buildpack in the service broker's manifest.yml and update the pinned
Ruby version in the service broker's Gemfile to ~> 2.7. This captures the idea that
the service broker works for all 2.x Ruby versions from 2.7 and up, anything less has reached end of life.
[cyberark/conjur-service-broker#266](https://github.com/cyberark/conjur-service-broker/pull/266)
* **Security**
    - Upgrade nokogiri to 1.13.4 to resolve CVE-2022-24836, CVE-2018-25032,
CVE-2022-24839, and CVE-2022-23437 (not vulnerable to all)
[cyberark/conjur-service-broker#273](https://github.com/cyberark/conjur-service-broker/pull/273)
    - Upgraded puma to 5.6.4 to resolve CVE-2022-24790
[cyberark/conjur-service-broker#271](https://github.com/cyberark/conjur-service-broker/pull/271)
    - Upgraded rails components to 5.2.6.2 and puma to 5.6.2 to resolve CVE-2022-23633 and
CVE-2022-23634 [cyberark/conjur-service-broker#270](https://github.com/cyberark/conjur-service-broker/pull/270)
    - Updated puma to 5.5.1
[cyberark/conjur-service-broker#267](https://github.com/cyberark/conjur-service-broker/pull/267)
    - Update rails components to 5.2.7.1 to resolve CVE-2022-22577 and CVE-2022-27777
[cyberark/conjur-service-broker#274](https://github.com/cyberark/conjur-service-broker/pull/274)
#### [v1.2.5](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.5) (2022-06-16)
* **Changed**
    - Upgrade conjur-api-go to v0.10.1 and rack to 2.2.3.1
[cyberark/conjur-service-broker#285](https://github.com/cyberark/conjur-service-broker/pull/285)
* **Security**
    - Upgrade nokogiri to 1.13.6 to resolve un-numbered libxml CVEs
[cyberark/conjur-service-broker#280](https://github.com/cyberark/conjur-service-broker/pull/280)
    - Upgrade rack to 2.2.3.1 to resolves CVE-2022-30122 and CVE-2022-30123
[cyberark/conjur-service-broker#283](https://github.com/cyberark/conjur-service-broker/pull/283)

### cyberark/conjur-authn-k8s-client

#### [v0.23.0](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.23.0) (2022-01-14)
* **Added**
    - Add support for tracing with OpenTelemetry. This adds a new function to the authenticator, AuthenticateWithContext. The existing funtion, Authenticate() is deprecated and will be removed in a future upddate. [cyberark/conjur-authn-k8s-client#423](https://github.com/cyberark/conjur-authn-k8s-client/pull/423)
    - Add support for Authn-JWT flow. [cyberark/conjur-authn-k8s-client#426](https://github.com/cyberark/conjur-authn-k8s-client/pull/426)
    - Add support for configuration via Pod Annotations. [[cyberark/conjur-authn-k8s-client#407](https://github.com/cyberark/conjur-authn-k8s-client/pull/407)
* **Changed**
    - The project Golang version is updated from the end-of-life v1.15 to version v1.17.
[cyberark/conjur-authn-k8s-client#416](https://github.com/cyberark/conjur-authn-k8s-client/pull/416)
[cyberark/conjur-authn-k8s-client#424](https://github.com/cyberark/conjur-authn-k8s-client/pull/424)
    - Reduced default timeout for waitForFile from 1s to 50ms. [cyberark/conjur-authn-k8s-client#423](https://github.com/cyberark/conjur-authn-k8s-client/pull/423)
    - Instead of getting K8s config object now you get Config Interface using NewConfigFromEnv() and ConfigFromEnv().
This is a breaking change for software that leverages the github.com/cyberark/conjur-authn-k8s-client/pkg/authenticator
Go package (e.g. Secretless and Secrets Provider for Kubernetes).
[cyberark/conjur-authn-k8s-client#425](https://github.com/cyberark/conjur-authn-k8s-client/pull/425)
    - Instead of getting K8s authenticator object now you get Authenticator Interface using NewAuthenticator() and NewAuthenticatorWithAccessToken(). [cyberark/conjur-authn-k8s-client#425](https://github.com/cyberark/conjur-authn-k8s-client/pull/425)
* **Fixed**
    - Allows the Conjur certificate path in the conjur-config-cluster-prep Helm chart to be set to
any user specified directory. [cyberark/conjur-authn-k8s-client#434](https://github.com/cyberark/conjur-authn-k8s-client/pull/434)
#### [v0.23.1](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.23.1) (2022-02-11)
* **Added**
    - Authenticator client logs request IP address after login error.
[cyberark/conjur-authn-k8s-client#439](https://github.com/cyberark/conjur-authn-k8s-client/pull/439)
* **Changed**
    - If Cluster Prep Helm chart value authnK8s.clusterRole.create or
authnK8s.serviceAccount.create is false, their corresponding name is no
longer required, as these objects are not required for Authn-JWT.
[cyberark/conjur-authn-k8s-client#445](https://github.com/cyberark/conjur-authn-k8s-client/pull/445)
[cyberark/conjur-authn-k8s-client#452](https://github.com/cyberark/conjur-authn-k8s-client/pull/452)
* **Fixed**
    - Fixes bug in Namespace Prep Helm chart's conjur_connect_configmap.yaml,
which silently accepted missing values from the referenced Golden ConfigMap.
[cyberark/conjur-authn-k8s-client#447](https://github.com/cyberark/conjur-authn-k8s-client/pull/447)
#### [v0.23.3](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.23.3) (2022-05-19)
* **Security**
    - Update base image in bin/test-workflow/test_app_summon/Dockerfile.builder to Ruby 3
[cyberark/conjur-authn-k8s-client#464](https://github.com/cyberark/conjur-authn-k8s-client/pull/464)
#### [v0.23.5](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.23.5) (2022-06-14)
* **Changed**
    - Update github.com/stretchr/testify to v1.7.2 and go.opentelemetry.io/otel to v1.7.0
[cyberark/conjur-authn-k8s-client#472](https://github.com/cyberark/conjur-authn-k8s-client/pull/472)
* **Security**
    - Update the Red Hat ubi image in Dockerfile
[cyberark/conjur-authn-k8s-client#471](https://github.com/cyberark/conjur-authn-k8s-client/pull/471)
#### [v0.23.6](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.23.6) (2022-06-16)
* **Security**
    - Added replace statement for gopkg.in/yaml.v3 prior to v3.0.1
[cyberark/conjur-authn-k8s-client#475](https://github.com/cyberark/conjur-authn-k8s-client/pull/475)

### cyberark/secrets-provider-for-k8s

#### [v1.4.0](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.4.0) (2022-02-15)
* **Added**
    - Adds support for Secrets Provider secrets rotation feature, Community release.
[cyberark/secrets-provider-for-k8s#426](https://github.com/cyberark/secrets-provider-for-k8s/pull/426)
[cyberark/secrets-provider-for-k8s#432](https://github.com/cyberark/secrets-provider-for-k8s/pull/432)
    - Adds support for Authn-JWT.
[cyberark/secrets-provider-for-k8s#431](https://github.com/cyberark/secrets-provider-for-k8s/pull/431)
[cyberark/secrets-provider-for-k8s#433](https://github.com/cyberark/secrets-provider-for-k8s/pull/433)
#### [v1.4.1](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.4.1) (2022-04-01)
* **Added**
    - Secrets files are written in an atomic operation. [cyberark/secrets-provider-for-k8s#440](https://github.com/cyberark/secrets-provider-for-k8s/pull/440)
    - Secret files are deleted when secrets are removed from Conjur or access is revoked. Can be disabled with annotation.
[cyberark/secrets-provider-for-k8s#447](https://github.com/cyberark/secrets-provider-for-k8s/pull/447)
    - Kubernetes Secrets are cleared when secrets are removed from Conjur or access is revoked. Can be disabled with annotation.
[cyberark/secrets-provider-for-k8s#449](https://github.com/cyberark/secrets-provider-for-k8s/pull/449)
    - Secrets Provider allows for its status to be monitored through the creation of a couple of empty sentinel files: CONJUR_SECRETS_PROVIDED and CONJUR_SECRETS_UPDATED. The first file is created when SP has completed its first round of providing secrets via secret files / Kubernetes Secrets. It creates/recreates the second file whenever it has updated secret files / Kubernetes Secrets. If desirable, application containers can mount these files via a shared volume.
[cyberark/secrets-provider-for-k8s#450](https://github.com/cyberark/secrets-provider-for-k8s/pull/450)
    - Adds support for secrets rotation with Kubernetes Secrets.
[cyberark/secrets-provider-for-k8s#448](https://github.com/cyberark/secrets-provider-for-k8s/pull/448)
* **Changed**
    - Update to automated release process. [cyberark/secrets-provider-for-k8s#455](https://github.com/cyberark/secrets-provider-for-k8s/pull/455)
#### [v1.4.3](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.4.3) (2022-07-07)
* **Removed**
    - Support for OpenShift v3.11 is officially removed as of this release.
[cyberark/secrets-provider-for-k8s#474](https://github.com/cyberark/secrets-provider-for-k8s/pull/474)
* **Security**
    - Add replace statements to go.mod to prune vulnerable dependency versions from the dependency tree.
[cyberark/secrets-provider-for-k8s#470](https://github.com/cyberark/secrets-provider-for-k8s/pull/470)
[cyberark/secrets-provider-for-k8s#471](https://github.com/cyberark/secrets-provider-for-k8s/pull/471)
    - Update the Red Hat ubi image in Dockerfile.
[cyberark/secrets-provider-for-k8s#469](https://github.com/cyberark/secrets-provider-for-k8s/pull/469)

### cyberark/secretless-broker

#### [v1.7.9](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.9) (2022-01-14)
* **Changed**
    - Use latest version of conjur-authn-k8s-client which supports JWT loging and tracing.
[cyberark/secretless-broker#1446](https://github.com/cyberark/secretless-broker/pull/1446)
#### [v1.7.10](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.10) (2022-02-15)
* **Fixed**
    - Postgres connector has been updated to propagate client options through Secretless to target server.
[cyberark/secretless-broker#1444](https://github.com/cyberark/secretless-broker/pull/1444)
* **Security**
    - Updated github.com/containerd/containerd to resolve GHSA-5j5w-g665-5m35
[cyberark/secretless-broker#1450](https://github.com/cyberark/secretless-broker/pull/1450)
#### [v1.7.11](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.11) (2022-04-29)
* **Added**
    - Support for building on Apple M1 hardware.
[cyberark/secretless-broker#1456](https://github.com/cyberark/secretless-broker/pull/1456)
* **Security**
    - Updated github.com/containerd/containerd to resolve CVE-2022-23648
[cyberark/secretless-broker#1459](https://github.com/cyberark/secretless-broker/pull/1459)
    - Updated github.com/docker/docker to resolve CVE-2015-3627
[cyberark/secretless-broker#1459](https://github.com/cyberark/secretless-broker/pull/1459)
    - Updated github.com/docker/distribution to resolve GHSA-qq97-vm5h-rrhg
[cyberark/secretless-broker#1459](https://github.com/cyberark/secretless-broker/pull/1459)
#### [v1.7.12](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.12) (2022-05-02)
* **Changed**
    - Update to automated release process
[cyberark/secretless-broker#1462](https://github.com/cyberark/secretless-broker/pull/1462)
#### [v1.7.13](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.13) (2022-07-07)
* **Changed**
    - Updated direct dependencies in bin/juxtaposer/go.mod and in go.mod and add replace statements
for known vulnerable third-party versions.
[cyberark/secretless-broker#1467](https://github.com/cyberark/secretless-broker/pull/1467)

### cyberark/summon

#### [v0.9.1](https://github.com/cyberark/summon/releases/tag/v0.9.1) (2021-12-22)
* **Changed**
    - Update go to 1.17 & switch to github.com/urfave/cli
from github.com/codegangsta/cli
[cyberark/summon#226](https://github.com/cyberark/summon/pull/226)
#### [v0.9.2](https://github.com/cyberark/summon/releases/tag/v0.9.2) (2022-05-31)
* **Security**
    - Update main and acceptance base images to Golang 1.17 to fix CVE-2022-0778 and CVE-2022-1292.
[cyberark/summon#232](https://github.com/cyberark/summon/pull/232/)
#### [v0.9.3](https://github.com/cyberark/summon/releases/tag/v0.9.3) (2022-06-15)
* **Changed**
    - Updated dependencies in go.mod (github.com/stretchr/testify -> 1.7.2,
github.com/urfave/cli -> 1.22.9, golang.org/x/net -> v0.0.0-20220607020251-c690dde0001d,
gopkg.in/yaml.v3 -> v3.0.1)
[cyberark/summon#234](https://github.com/cyberark/summon/pull/234)

### cyberark/summon-conjur

#### [v0.6.1](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.1) (2021-12-31)
* **Changed**
    - Updated Golang to 1.17 and the Conjur API to 0.8.1
[cyberark/summon-conjur#96](https://github.com/cyberark/summon-conjur/pull/96/)
#### [v0.6.2](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.2) (2022-02-25)
* **Changed**
    - Updated Conjur API to 0.9.0 to support authn-JWT
[cyberark/summon-conjur#99](https://github.com/cyberark/summon-conjur/pull/99/)
#### [v0.6.3](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.3) (2022-05-19)
* **Changed**
    - Updated the Conjur API to 0.10.0 to support the new CONJUR_AUTHN_JWT_HOST_ID environment variable
[cyberark/summon-conjur#103](https://github.com/cyberark/summon-conjur/pull/103/)
* **Security**
    - Update test env Golang to 1.17 to fix CVE-2022-0778 and CVE-2022-1292.
[cyberark/summon-conjur#102](https://github.com/cyberark/summon-conjur/pull/102/)
#### [v0.6.4](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.4) (2022-07-06)
* **Changed**
    - Updated direct dependencies (github.com/cyberark/conjur-api-go -> v0.10.1,
github.com/stretchr/testify -> 1.7.2)
[cyberark/summon-conjur#106](https://github.com/cyberark/summon-conjur/pull/106)
