### PR TITLE
Update suite.yml for v18.0.0+suite1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.18.0+suite.1] - 2022-08-23
+
 ## [v1.17.6+suite.1] - 2022-05-17
 
 ### Changed
@@ -82,7 +84,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   open in a new window, unless the link points to a CyberArk docs site.
   [cyberark/conjur-oss-suite-release#199](https://github.com/cyberark/conjur-oss-suite-release/issues/199)
 
-[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.17.6+suite.1...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.18.0+suite.1...HEAD
+[v1.18.0+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.15.0+suite.1...v1.18.0+suite.1
 [v1.17.6+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.15.0+suite.1...v1.17.6+suite.1
 [v1.15.0+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.14.1+suite.1...v1.15.0+suite.1
 [v1.14.1+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.13.1+suite.1...v1.14.1+suite.1

--- a/suite.yml
+++ b/suite.yml
@@ -11,7 +11,7 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.17.6
+        version: v1.18.0
       - name: cyberark/conjur-openapi-spec
         url: https://github.com/cyberark/conjur-openapi-spec
         description: Conjur OpenAPI v3 specification
@@ -20,7 +20,7 @@ section:
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
         upgrade_url: https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment
-        version: v2.0.4
+        version: v2.0.5
 
   - name: Conjur SDK
     description: Conjur Command Line Interface (CLI) and Client Libraries
@@ -28,7 +28,7 @@ section:
       - name: cyberark/conjur-cli
         url: https://github.com/cyberark/conjur-cli
         description: Conjur Ruby CLI
-        version: v6.2.5
+        version: v6.2.8
       - name: cyberark/conjur-api-dotnet
         url: https://github.com/cyberark/conjur-api-dotnet
         description: Conjur .Net Client Library
@@ -48,7 +48,7 @@ section:
       - name: cyberark/conjur-api-ruby
         url: https://github.com/cyberark/conjur-api-ruby
         description: Conjur Ruby Client Library
-        version: v5.3.7
+        version: v5.4.0
 
   - name: Platform Integrations
     description: Tools for Conjur integrations with platforms and cloud providers.
@@ -63,20 +63,20 @@ section:
         url: https://github.com/cyberark/conjur-service-broker
         description: The Conjur Service Broker provides your applications running
           in Cloud Foundry with a Conjur identity.
-        version: v1.2.5
+        version: v1.2.6
       - name: cyberark/conjur-authn-k8s-client
         url: https://github.com/cyberark/conjur-authn-k8s-client
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        version: v0.23.6
+        version: v0.23.7
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
         tool: Kubernetes
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        version: v1.4.3
+        version: v1.4.4
 
   - name: DevOps Tools
     description: Conjur OSS integrations with DevOps tools.
@@ -108,7 +108,7 @@ section:
         tool: Terraform
         description: Terraform provider that makes secrets in Conjur available in
           Terraform manifests.
-        version: v0.6.2
+        version: v0.6.3
 
   - name: Secretless Broker
     description: Secure your apps by making them Secretless.
@@ -118,7 +118,7 @@ section:
         description: Secretless Broker can be used to securely connect your
           applications to services they need - without ever having to fetch or
           manage passwords and keys.
-        version: v1.7.13
+        version: v1.7.14
 
   - name: Summon
     description: Run your processes wrapped with Summon to ensure they have
@@ -128,7 +128,7 @@ section:
         url: https://github.com/cyberark/summon
         description: Summon is a secure tool to inject secrets into a subprocess
           environment.
-        version: v0.9.3
+        version: v0.9.4
       - name: cyberark/summon-conjur
         url: https://github.com/cyberark/summon-conjur
         description: Summon provider for Conjur.


### PR DESCRIPTION
# Release Notes
All notable changes to this project will be documented in this file.

## [1.18.0] - 2022-08-24

## Table of Contents

- [Components](#components)
- [Installation Instructions for the Suite Release Version of Conjur](#installation-instructions-for-the-suite-release-version-of-conjur)
- [Upgrade Instructions](#upgrade-instructions)
- [Changes](#changes)

## Components

These are the components that combine to create this Conjur OSS Suite release and links
to their releases:

### Conjur Server
- **[cyberark/conjur v1.18.0](https://github.com/cyberark/conjur/releases/tag/v1.18.0)** (2022-08-01) 
- **[cyberark/conjur-openapi-spec v5.3.0](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.3.0)** (2021-12-22) 
- **[cyberark/conjur-oss-helm-chart v2.0.5](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.5)** (2022-08-17) 

### Conjur SDK
- **[cyberark/conjur-cli v6.2.8](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.8)** (2022-08-16) 
- **[cyberark/conjur-api-dotnet v2.1.1](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.1.1)** (2022-03-14) 
- **[cyberark/conjur-api-go v0.10.1](https://github.com/cyberark/conjur-api-go/releases/tag/v0.10.1)** (2022-06-14) 
- **[cyberark/conjur-api-java v3.0.3](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.3)** (2022-05-31) 
- **[cyberark/conjur-api-python3 v7.1.0](https://github.com/cyberark/conjur-api-python3/releases/tag/v7.1.0)** (2021-12-22) 
- **[cyberark/conjur-api-ruby v5.4.0](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.4.0)** (2022-08-16) 

### Platform Integrations
- **[cyberark/cloudfoundry-conjur-buildpack v2.2.4](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.4)** (2022-06-16) 
- **[cyberark/conjur-service-broker v1.2.6](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.6)** (2022-08-16) 
- **[cyberark/conjur-authn-k8s-client v0.23.7](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.23.7)** (2022-07-12) 
- **[cyberark/secrets-provider-for-k8s v1.4.4](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.4.4)** (2022-07-12) 

### DevOps Tools
- **[cyberark/ansible-conjur-collection v1.1.0](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.1.0)** (2020-12-29) 
- **[cyberark/ansible-conjur-host-identity v0.3.2](https://github.com/cyberark/ansible-conjur-host-identity/releases/tag/v0.3.2)** (2020-12-29) 
- **[cyberark/conjur-puppet v3.1.0](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.0)** (2020-10-08) 
- **[cyberark/terraform-provider-conjur v0.6.3](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.3)** (2022-08-17) 

### Secretless Broker
- **[cyberark/secretless-broker v1.7.14](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.14)** (2022-08-17) 

### Summon
- **[cyberark/summon v0.9.4](https://github.com/cyberark/summon/releases/tag/v0.9.4)** (2022-08-18) 
- **[cyberark/summon-conjur v0.6.4](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.4)** (2022-07-06) 

## Installation Instructions for the Suite Release Version of Conjur

Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.

+ **Docker or docker-compose**

  Set the container image tag to `cyberark/conjur:1.18.0`.
  For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
  ```
  image: cyberark/conjur:1.18.0
  ```

+ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

  Update the `image.tag` value and use the appropriate release of the helm chart:
  ```
  helm install ... \
    --set image.tag="1.18.0" \
    ...
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v2.0.5/conjur-oss-2.0.5.tgz
  ```

## Upgrade Instructions

Upgrade instructions are available for the following components:
- [cyberark/conjur](https://github.com/cyberark/conjur/blob/master/UPGRADING.md)
- [cyberark/conjur-oss-helm-chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)

## Changes
The following are changes to the constituent components since the last Conjur
OSS Suite release:
- [cyberark/conjur](#cyberarkconjur)
- [cyberark/conjur-oss-helm-chart](#cyberarkconjur-oss-helm-chart)
- [cyberark/conjur-cli](#cyberarkconjur-cli)
- [cyberark/conjur-api-ruby](#cyberarkconjur-api-ruby)
- [cyberark/conjur-service-broker](#cyberarkconjur-service-broker)
- [cyberark/conjur-authn-k8s-client](#cyberarkconjur-authn-k8s-client)
- [cyberark/secrets-provider-for-k8s](#cyberarksecrets-provider-for-k8s)
- [cyberark/terraform-provider-conjur](#cyberarkterraform-provider-conjur)
- [cyberark/secretless-broker](#cyberarksecretless-broker)
- [cyberark/summon](#cyberarksummon)

### cyberark/conjur

#### [v1.17.7](https://github.com/cyberark/conjur/releases/tag/v1.17.7) (2022-06-29)
* **Changed**
    - Made simplecov a dev/test dependency
[cyberark/conjur#2564](https://github.com/cyberark/conjur/pull/2564)
    - Added configuration for token TTL
[cyberark/conjur#2510](https://github.com/cyberark/conjur/pull/2510)
    - Added configuration for default value for maximum number of results return to /resources request
[cyberark/conjur#2510](https://github.com/cyberark/conjur/pull/2510)
* **Fixed**
    - Previously, the temporary schemas used to modify Conjur policy
caused the Postgres database catalog cache to leak memory over time,
leading to an eventual crash. Now, we recycle the database
connection after modifying policy to free this cache and prevent
the memory leak from occurring.
[cyberark/conjur#2584](https://github.com/cyberark/conjur/pull/2584)
* **Security**
    - Update rack to 2.2.3.1 to resolve CVE-2022-3023
[cyberark/conjur#2564](https://github.com/cyberark/conjur/pull/2564)
    - Update nokogiri to 1.13.6 to resolve un-numbered libxml CVEs (both in main
Gemfile.lock and in docs/Gemfile.lock)
[cyberark/conjur#2558](https://github.com/cyberark/conjur/pull/2558)
#### [v1.18.0](https://github.com/cyberark/conjur/releases/tag/v1.18.0) (2022-08-01)
* **Added**
    - Adds support for namespace label based identity scope for the Kubernetes Authenticator
[cyberark/conjur#2613](https://github.com/cyberark/conjur/pull/2613)
* **Changed**
    - Adds support for authentication using OIDC's code authorization flow
[cyberark/conjur#2595](https://github.com/cyberark/conjur/pull/2595)
* **Security**
    - Updated tzinfo to 1.2.10 to address CVE-2022-31163
[cyberark/conjur#2610](https://github.com/cyberark/conjur/pull/2610)

### cyberark/conjur-oss-helm-chart

#### [v2.0.5](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.5) (2022-08-17)
* **Added**
    - Support for authn-jwt flow. [cyberark/conjur-oss-helm-chart#169](https://github.com/cyberark/conjur-oss-helm-chart/pull/169)

### cyberark/conjur-cli

#### [v6.2.6](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.6) (2022-01-31)
* **Changed**
    - Allow activesupport >=6 as a dependency for ruby-3.0.2.
[cyberark/conjur-cli#339](https://github.com/cyberark/conjur-cli/pull/339)
    - Add Ruby 3 tests in CI.
    - Set Ruby 3 as default.
[cyberark/conjur-cli#344](https://github.com/cyberark/conjur-cli/pull/344)
    - Bump conjur-api-ruby gem.
    - Bump rake gem.
#### [v6.2.7](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.7) (2022-05-09)
* **Changed**
    - Remove support for Ruby versions 2.5 and 2.6 [cyberark/cyberark-conjur-cli-docker-based#351](https://github.com/cyberark/cyberark-conjur-cli-docker-based/pull/351)
#### [v6.2.8](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.8) (2022-08-16)
* **Fixed**
    - Fixed rubygems delivery [cyberark/cyberark-conjur-cli-docker-based#354](https://github.com/cyberark/cyberark-conjur-cli-docker-based/pull/354)

### cyberark/conjur-api-ruby

#### [v5.4.0](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.4.0) (2022-08-16)
* **Added**
    - Added support for OIDC V2 authentication endpoint.
[cyberark/cojnur-api-ruby#207](https://github.com/cyberark/conjur-api-ruby/pull/207)
    - Added support for OIDC authenticator providers endpoint.
[cyberark/cojnur-api-ruby#207](https://github.com/cyberark/conjur-api-ruby/pull/207)
* **Changed**
    - Remove support for Ruby versions <2.7 which are [end of life](https://endoflife.date/ruby).
[cyberark/conjur-api-ruby#206](https://github.com/cyberark/conjur-api-ruby/pull/206)
    - Adding operation call to fetch authentication providers
[cyberark/conjur-api-ruby#206](https://github.com/cyberark/conjur-api-ruby/pull/206)

### cyberark/conjur-service-broker

#### [v1.2.6](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.6) (2022-08-16)
* **Security**
    - Updated tzinfo to 1.2.10 in Gemfile.lock and test/integration/test-app/Gemfile.lock to
resolve CVE-2022-31163
[cyberark/conjur-service-broker#289](https://github.com/cyberark/conjur-service-broker/pull/289)
    - Updated rails-html-sanitizer to 1.4.3 to resolve CVE-2022-32209
[cyberark/conjur-service-broker#288](https://github.com/cyberark/conjur-service-broker/pull/288)

### cyberark/conjur-authn-k8s-client

#### [v0.23.7](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.23.7) (2022-07-12)
* **Changed**
    - Updated dev/Dockerfile.debug and removed bin/test-workflow/test-app-summon/Dockerfile.builder
and bin/test-workflow/test-app-summon/Dockerfile.oc
[cyberark/conjur-authn-k8s-client#480](https://github.com/cyberark/conjur-authn-k8s-client/pull/480)

### cyberark/secrets-provider-for-k8s

#### [v1.4.4](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.4.4) (2022-07-12)
* **Changed**
    - Updated multiple go dependencies
[cyberark/secrets-provider-for-k8s#477](https://github.com/cyberark/secrets-provider-for-k8s/pull/477)
* **Fixed**
    - Fixes the following error seen on boot up when the status volumemount is not added
"open /conjur/status/conjur-secrets-unchanged.sh: no such file or directory"
[cyberark/secrets-provider-for-k8s#479](https://github.com/cyberark/secrets-provider-for-k8s/pull/479)
* **Security**
    - Add replace statements to go.mod to prune vulnerable dependency versions from the dependency tree.
[cyberark/secrets-provider-for-k8s#478](https://github.com/cyberark/secrets-provider-for-k8s/pull/478)

### cyberark/terraform-provider-conjur

#### [v0.6.3](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.3) (2022-08-17)
* **Changed**
    - Updated Terraform Plugin SDK to v2. This removes support for Terraform 0.11.
[cyberark/terraform-provider-conjur#106](https://github.com/cyberark/terraform-provider-conjur/pull/106)
    - Updated direct dependencies (conjur-api-go -> 0.10.1 and github.com/hashicorp/terraform-plugin-sdk -> 1.17.2)
[cyberark/terraform-provider-conjur#102](https://github.com/cyberark/terraform-provider-conjur/pull/102)
* **Security**
    - Add replace statements to go.mod to remove 3rd party dependencies with known vulnerabilities from our
dependency tree. [cyberark/terraform-provider-conjur#103](https://github.com/cyberark/terraform-provider-conjur/pull/103)
[cyberark/terraform-provider-conjur#104](https://github.com/cyberark/terraform-provider-conjur/pull/104)
[cyberark/terraform-provider-conjur#105](https://github.com/cyberark/terraform-provider-conjur/pull/105)
[cyberark/terraform-provider-conjur#107](https://github.com/cyberark/terraform-provider-conjur/pull/107)

### cyberark/secretless-broker

#### [v1.7.14](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.14) (2022-08-17)
* **Security**
    - Added replace & exclude statements to go.mod to remove dependency on
github.com/emicklei/go-restful v2.8.5 to resolve CVE-2022-1996
[cyberark/secretless-broker#1473](https://github.com/cyberark/secretless-broker/pull/1473)

### cyberark/summon

#### [v0.9.4](https://github.com/cyberark/summon/releases/tag/v0.9.4) (2022-08-18)
* **Security**
    - Replaced gopkg.in/yaml.v2 v2.2.2 with v2.2.8 to address
SNYK-GOLANG-GOPKGINYAMLV2-1533594 and CVE-2019-11254
[cyberark/summon#236](https://github.com/cyberark/summon/pull/236)
