### PR TITLE
Update suite.yml for v1.18.4+suite.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.18.4+suite.1] - 2022-09-16
+
 ## [v1.18.0+suite.1] - 2022-08-23
 
 ## [v1.17.6+suite.1] - 2022-05-17
@@ -84,8 +86,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   open in a new window, unless the link points to a CyberArk docs site.
   [cyberark/conjur-oss-suite-release#199](https://github.com/cyberark/conjur-oss-suite-release/issues/199)
 
-[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.18.0+suite.1...HEAD
-[v1.18.0+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.15.0+suite.1...v1.18.0+suite.1
+[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.18.4+suite.1...HEAD
+[v1.18.4+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.18.0+suite.1...v1.18.4+suite.1
+[v1.18.0+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.17.6+suite.1...v1.18.0+suite.1
 [v1.17.6+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.15.0+suite.1...v1.17.6+suite.1
 [v1.15.0+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.14.1+suite.1...v1.15.0+suite.1
 [v1.14.1+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.13.1+suite.1...v1.14.1+suite.1

--- a/suite.yml
+++ b/suite.yml
@@ -11,7 +11,7 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.18.0
+        version: v1.18.4
       - name: cyberark/conjur-openapi-spec
         url: https://github.com/cyberark/conjur-openapi-spec
         description: Conjur OpenAPI v3 specification
@@ -58,7 +58,7 @@ section:
         description: The Conjur Buildpack will use the Conjur identity provided
           by the Conjur Service Broker to inject secrets into your application
           environment at runtime.
-        version: v2.2.4
+        version: v2.2.5
       - name: cyberark/conjur-service-broker
         url: https://github.com/cyberark/conjur-service-broker
         description: The Conjur Service Broker provides your applications running
@@ -69,7 +69,7 @@ section:
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        version: v0.23.7
+        version: v0.23.8
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
         tool: Kubernetes
@@ -88,7 +88,7 @@ section:
           Includes an Ansible role to bootstrap Ansible hosts with a Conjur
           identity, and a lookup plugin to enable easy access to Conjur secrets
           from within your Ansible playbooks, etc.
-        version: v1.1.0
+        version: v1.2.0
       - name: cyberark/ansible-conjur-host-identity
         url: https://github.com/cyberark/ansible-conjur-host-identity
         tool: Ansible


### PR DESCRIPTION
# Release Notes
All notable changes to this project will be documented in this file.

## [v1.18.4+suite.1] - 2022-09-16

## Table of Contents

- [Components](#components)
- [Installation Instructions for the Suite Release Version of Conjur](#installation-instructions-for-the-suite-release-version-of-conjur)
- [Upgrade Instructions](#upgrade-instructions)
- [Changes](#changes)

## Components

These are the components that combine to create this Conjur OSS Suite release and links
to their releases:

### Conjur Server
- **[cyberark/conjur v1.18.4](https://github.com/cyberark/conjur/releases/tag/v1.18.4)** (2022-09-11) 
- **[cyberark/conjur-openapi-spec v5.3.0](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.3.0)** (2021-12-22) 
- **[cyberark/conjur-oss-helm-chart v2.0.5](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.5)** (2022-08-17) 

### Conjur SDK
- **[cyberark/conjur-cli v6.2.8](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.8)** (2022-08-16) 
- **[cyberark/conjur-api-dotnet v2.1.1](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.1.1)** (2022-03-14) 
- **[cyberark/conjur-api-go v0.10.1](https://github.com/cyberark/conjur-api-go/releases/tag/v0.10.1)** (2022-06-14) 
- **[cyberark/conjur-api-java v3.0.3](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.3)** (2022-05-31) 
- **[cyberark/conjur-api-python3 v7.1.0](https://github.com/cyberark/conjur-api-python3/releases/tag/v7.1.0)** (2021-12-22) 
- **[cyberark/conjur-api-ruby v5.4.0](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.4.0)** (2022-08-16) 

### Platform Integrations
- **[cyberark/cloudfoundry-conjur-buildpack v2.2.5](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.5)** () 
- **[cyberark/conjur-service-broker v1.2.6](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.6)** (2022-08-16) 
- **[cyberark/conjur-authn-k8s-client v0.23.8](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.23.8)** (2022-08-31) 
- **[cyberark/secrets-provider-for-k8s v1.4.4](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.4.4)** (2022-07-12) 

### DevOps Tools
- **[cyberark/ansible-conjur-collection v1.2.0](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.2.0)** (2020-09-01) 
- **[cyberark/ansible-conjur-host-identity v0.3.2](https://github.com/cyberark/ansible-conjur-host-identity/releases/tag/v0.3.2)** (2020-12-29) 
- **[cyberark/conjur-puppet v3.1.0](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.0)** (2020-10-08) 
- **[cyberark/terraform-provider-conjur v0.6.3](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.3)** (2022-08-17) 

### Secretless Broker
- **[cyberark/secretless-broker v1.7.14](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.14)** (2022-08-17) 

### Summon
- **[cyberark/summon v0.9.4](https://github.com/cyberark/summon/releases/tag/v0.9.4)** (2022-08-18) 
- **[cyberark/summon-conjur v0.6.4](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.4)** (2022-07-06) 

## Installation Instructions for the Suite Release Version of Conjur

Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.

+ **Docker or docker-compose**

  Set the container image tag to `cyberark/conjur:1.18.4`.
  For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
  ```
  image: cyberark/conjur:1.18.4
  ```

+ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

  Update the `image.tag` value and use the appropriate release of the helm chart:
  ```
  helm install ... \
    --set image.tag="1.18.4" \
    ...
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v2.0.5/conjur-oss-2.0.5.tgz
  ```

## Upgrade Instructions

Upgrade instructions are available for the following components:
- [cyberark/conjur](https://github.com/cyberark/conjur/blob/master/UPGRADING.md)
- [cyberark/conjur-oss-helm-chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)

## Changes
The following are changes to the constituent components since the last Conjur
OSS Suite release:
- [cyberark/conjur](#cyberarkconjur)
- [cyberark/conjur-authn-k8s-client](#cyberarkconjur-authn-k8s-client)
- [cyberark/ansible-conjur-collection](#cyberarkansible-conjur-collection)

### cyberark/conjur

#### [v1.18.1](https://github.com/cyberark/conjur/releases/tag/v1.18.1) (2022-08-01)
* **Changed**
    - Migrates OIDC Provider list to be accessable via an unauthentated
endpoint. This is not a concern as logins using this endpoint already
display the redirect endpoint on the login page.
[cyberark/conjur#2625](https://github.com/cyberark/conjur/pull/2625)
#### [v1.18.2](https://github.com/cyberark/conjur/releases/tag/v1.18.2) (2022-09-01)
* **Changed**
    - Reduces debug log verbosity.
[cyberark/conjur#2639](https://github.com/cyberark/conjur/pull/2639)
#### [v1.18.3](https://github.com/cyberark/conjur/releases/tag/v1.18.3) (2022-09-07)
* **Security**
    - Remove code and state from the debug logs
[conjurinc/conjur-ui#2644](https://github.com/cyberark/conjur/pull/2644)
#### [v1.18.4](https://github.com/cyberark/conjur/releases/tag/v1.18.4) (2022-09-11)
* **Added**
    - Adds support for authorization token in header in OIDC authenticator.
[cyberark/conjur#2637](https://github.com/cyberark/conjur/pull/2637)

### cyberark/conjur-authn-k8s-client

#### [v0.23.8](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.23.8) (2022-08-31)
* **Changed**
    - Update Cluster Prep Helm chart to support namespace label-based authentication.
[cyberark/conjur-authn-k8s-client#482](https://github.com/cyberark/conjur-authn-k8s-client/pull/482)

### cyberark/ansible-conjur-collection

#### [v1.2.0](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.2.0) (2020-09-01)
* **Added**
    - Add state variable to Conjur Ansible role, which can be used to cleanup
configuration and identity artifacts created on managed nodes.
[cyberark/ansible-conjur-collection#176](https://github.com/cyberark/ansible-conjur-collection/pull/176)
* **Changed**
    - Lookup plugin now retries variable retrieval 5 times before accepting a
failure response.
[cyberark/ansible-conjur-collection#60](https://github.com/cyberark/ansible-conjur-collection/pull/60)
* **Removed**
    - End support for Python 2.
[cyberark/ansible-conjur-collection#69](https://github.com/cyberark/ansible-conjur-collection/pull/69)
