### PR TITLE
Remove --generator tag

### DIFF
--- a/release-testing/prepare.sh
+++ b/release-testing/prepare.sh
@@ -78,7 +78,7 @@ function register_conjur_client_pod() {
   local CONJUR_CLIENT_POD_NAME="conjur-client-pod"
 
   # Start the CLI pod
-  kubectl --namespace "${TEST_NAMESPACE}" run --generator=run-pod/v1 \
+  kubectl --namespace "${TEST_NAMESPACE}" run \
     "${CONJUR_CLIENT_POD_NAME}" \
     --restart='Never' \
     --image cyberark/conjur-cli:5 \


### PR DESCRIPTION
### Desired Outcome
 
CI is failing due to `error: unknown flag --generator`. [This was deprecated in from the `kubectl run`](https://github.com/kubernetes/kubernetes/pull/87077) command, which now only supports creating pods - all other generators were moved under `kubectl create`.

### Implemented Changes

Remove the --generator flag from `kubectl run`

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
