### PR TITLE
Release v1.19.0+suite.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.19.0+suite.1] - 2022-11-30
+
 ## [v1.18.4+suite.1] - 2022-09-16
 
 ## [v1.18.0+suite.1] - 2022-08-23
@@ -86,7 +88,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   open in a new window, unless the link points to a CyberArk docs site.
   [cyberark/conjur-oss-suite-release#199](https://github.com/cyberark/conjur-oss-suite-release/issues/199)
 
-[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.18.4+suite.1...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.0+suite.1...HEAD
+[v1.18.4+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.18.4+suite.1...v1.19.0+suite.1
 [v1.18.4+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.18.0+suite.1...v1.18.4+suite.1
 [v1.18.0+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.17.6+suite.1...v1.18.0+suite.1
 [v1.17.6+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.15.0+suite.1...v1.17.6+suite.1

--- a/suite.yml
+++ b/suite.yml
@@ -11,7 +11,7 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.18.4
+        version: v1.19.0
       - name: cyberark/conjur-openapi-spec
         url: https://github.com/cyberark/conjur-openapi-spec
         description: Conjur OpenAPI v3 specification
@@ -36,7 +36,7 @@ section:
       - name: cyberark/conjur-api-go
         url: https://github.com/cyberark/conjur-api-go
         description: Conjur Golang Client Library
-        version: v0.10.1
+        version: v0.10.2
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
@@ -58,25 +58,25 @@ section:
         description: The Conjur Buildpack will use the Conjur identity provided
           by the Conjur Service Broker to inject secrets into your application
           environment at runtime.
-        version: v2.2.5
+        version: v2.2.6
       - name: cyberark/conjur-service-broker
         url: https://github.com/cyberark/conjur-service-broker
         description: The Conjur Service Broker provides your applications running
           in Cloud Foundry with a Conjur identity.
-        version: v1.2.6
+        version: v1.2.7
       - name: cyberark/conjur-authn-k8s-client
         url: https://github.com/cyberark/conjur-authn-k8s-client
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        version: v0.23.8
+        version: v0.24.0
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
         tool: Kubernetes
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        version: v1.4.4
+        version: v1.4.5
 
   - name: DevOps Tools
     description: Conjur OSS integrations with DevOps tools.
@@ -108,7 +108,7 @@ section:
         tool: Terraform
         description: Terraform provider that makes secrets in Conjur available in
           Terraform manifests.
-        version: v0.6.3
+        version: v0.6.4
 
   - name: Secretless Broker
     description: Secure your apps by making them Secretless.
@@ -128,7 +128,7 @@ section:
         url: https://github.com/cyberark/summon
         description: Summon is a secure tool to inject secrets into a subprocess
           environment.
-        version: v0.9.4
+        version: v0.9.5
       - name: cyberark/summon-conjur
         url: https://github.com/cyberark/summon-conjur
         description: Summon provider for Conjur.


### PR DESCRIPTION
# Release Notes
All notable changes to this project will be documented in this file.

## [v1.19.0+suite.1] - 2022-11-30

## Table of Contents

- [Components](#components)
- [Installation Instructions for the Suite Release Version of Conjur](#installation-instructions-for-the-suite-release-version-of-conjur)
- [Upgrade Instructions](#upgrade-instructions)
- [Changes](#changes)

## Components

These are the components that combine to create this Conjur OSS Suite release and links
to their releases:

### Conjur Server
- **[cyberark/conjur v1.19.0](https://github.com/cyberark/conjur/releases/tag/v1.19.0)** (2022-11-29) 
- **[cyberark/conjur-openapi-spec v5.3.0](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.3.0)** (2021-12-22) 
- **[cyberark/conjur-oss-helm-chart v2.0.5](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.5)** (2022-08-17) 

### Conjur SDK
- **[cyberark/conjur-cli v6.2.8](https://github.com/cyberark/conjur-cli/releases/tag/v6.2.8)** (2022-08-16) 
- **[cyberark/conjur-api-dotnet v2.1.1](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.1.1)** (2022-03-14) 
- **[cyberark/conjur-api-go v0.10.2](https://github.com/cyberark/conjur-api-go/releases/tag/v0.10.2)** (2022-11-14) 
- **[cyberark/conjur-api-java v3.0.3](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.3)** (2022-05-31) 
- **[cyberark/conjur-api-python3 v7.1.0](https://github.com/cyberark/conjur-api-python3/releases/tag/v7.1.0)** (2021-12-22) 
- **[cyberark/conjur-api-ruby v5.4.0](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.4.0)** (2022-08-16) 

### Platform Integrations
- **[cyberark/cloudfoundry-conjur-buildpack v2.2.6](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.6)** (2022-11-23) 
- **[cyberark/conjur-service-broker v1.2.7](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.7)** (2022-11-27) 
- **[cyberark/conjur-authn-k8s-client v0.24.0](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.24.0)** (2022-11-23) 
- **[cyberark/secrets-provider-for-k8s v1.4.5](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.4.5)** (2022-09-26) 

### DevOps Tools
- **[cyberark/ansible-conjur-collection v1.2.0](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.2.0)** (2020-09-01) 
- **[cyberark/ansible-conjur-host-identity v0.3.2](https://github.com/cyberark/ansible-conjur-host-identity/releases/tag/v0.3.2)** (2020-12-29) 
- **[cyberark/conjur-puppet v3.1.0](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.0)** (2020-10-08) 
- **[cyberark/terraform-provider-conjur v0.6.4](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.4)** (2022-11-14) 

### Secretless Broker
- **[cyberark/secretless-broker v1.7.14](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.14)** (2022-08-17) 

### Summon
- **[cyberark/summon v0.9.5](https://github.com/cyberark/summon/releases/tag/v0.9.5)** (2022-09-28) 
- **[cyberark/summon-conjur v0.6.4](https://github.com/cyberark/summon-conjur/releases/tag/v0.6.4)** (2022-07-06) 

## Installation Instructions for the Suite Release Version of Conjur

Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.

+ **Docker or docker-compose**

  Set the container image tag to `cyberark/conjur:1.19.0`.
  For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
  ```
  image: cyberark/conjur:1.19.0
  ```

+ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

  Update the `image.tag` value and use the appropriate release of the helm chart:
  ```
  helm install ... \
    --set image.tag="1.19.0" \
    ...
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v2.0.5/conjur-oss-2.0.5.tgz
  ```

## Upgrade Instructions

Upgrade instructions are available for the following components:
- [cyberark/conjur](https://github.com/cyberark/conjur/blob/master/UPGRADING.md)
- [cyberark/conjur-oss-helm-chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)

## Changes
The following are changes to the constituent components since the last Conjur
OSS Suite release:
- [cyberark/conjur](#cyberarkconjur)
- [cyberark/conjur-api-go](#cyberarkconjur-api-go)
- [cyberark/cloudfoundry-conjur-buildpack](#cyberarkcloudfoundry-conjur-buildpack)
- [cyberark/conjur-service-broker](#cyberarkconjur-service-broker)
- [cyberark/conjur-authn-k8s-client](#cyberarkconjur-authn-k8s-client)
- [cyberark/secrets-provider-for-k8s](#cyberarksecrets-provider-for-k8s)
- [cyberark/terraform-provider-conjur](#cyberarkterraform-provider-conjur)
- [cyberark/summon](#cyberarksummon)

### cyberark/conjur

#### [v1.19.0](https://github.com/cyberark/conjur/releases/tag/v1.19.0) (2022-11-29)
* **Added**
    - Conjur policy loads can now emit callbacks to extensions on policy
load lifecycle events (e.g. before/after policy load). This is disabled
by default, but is available under the
CONJUR_FEATURE_POLICY_LOAD_EXTENSIONS feature flag.
[cyberark/conjur#2671](https://github.com/cyberark/conjur/pull/2671)
    - Conjur roles API can now emit callbacks to extensions on member add and
remove events (e.g. before/after add member). This is disabled by default,
but is available under the CONJUR_FEATURE_ROLES_API_EXTENSIONS feature flag.
[cyberark/conjur#2671](https://github.com/cyberark/conjur/pull/2671)
* **Security**
    - Updated nokogiri in root and docs Gemfile.lock files to resolve GHSA-2qc6-mcvw-92cw
[cyberark/conjur#2670](https://github.com/cyberark/conjur/pull/2670)

### cyberark/conjur-api-go

#### [v0.10.2](https://github.com/cyberark/conjur-api-go/releases/tag/v0.10.2) (2022-11-14)
* **Fixed**
    - Fixed bug with CONJUR_AUTHN_JWT_HOST_ID environment variable not being read
[cyberark/conjur-api-go#136](https://github.com/cyberark/conjur-api-go/pull/136)

### cyberark/cloudfoundry-conjur-buildpack

#### [v2.2.6](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.6) (2022-11-23)
* **Changed**
    - Added replace statement to prune gopkg.in/yaml.v2 v2.2.2 in favor of v2.2.8
[cyberark/cloudfoundry-conjur-buildpack#153](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/153)
    - Added replace statement to prune gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c from
dependency tree in favor of v3.0.1 [cyberark/cloudfoundry-conjur-buildpack#152](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/152)
* **Security**
    - Updated Summon, golang.org/x/net, and golang.org/x/text dependencies
[cyberark/cloudfoundry-conjur-buildpack#156](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/156)
    - Updated tests/integration/apps/java to use Spring Framework 2.7.5
[cyberark/cloudfoundry-conjur-buildpack#155](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/155)

### cyberark/conjur-service-broker

#### [v1.2.7](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.7) (2022-11-27)
* **Security**
    - Upgrade nokogiri to v1.3.9 to resolve GHSA-2qc6-mcvw-92cw
[cyberark/conjur-service-broker#296](https://github.com/cyberark/conjur-service-broker/pull/296)
    - Upgrade cucumber (2.99.0 -> 7.1.0) and aruba (1.1.2 -> 2.0.0)
to resolve medium severity security issue on Snyk
[cyberark/conjur-service-broker#294](https://github.com/cyberark/conjur-service-broker/pull/294)

### cyberark/conjur-authn-k8s-client

#### [v0.24.0](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.24.0) (2022-11-23)
* **Changed**
    - Add service account secret to Conjur Config Cluster Prep chart
[cyberark/conjur-authn-k8s-client#486](https://github.com/cyberark/conjur-authn-k8s-client/pull/486)

### cyberark/secrets-provider-for-k8s

#### [v1.4.5](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.4.5) (2022-09-26)
* **Changed**
    - Updated Go to 1.19
[cyberark/secrets-provider-for-k8s#484](https://github.com/cyberark/secrets-provider-for-k8s/pull/484)
    - Updated go.opentelmetry.io/otel to 1.10.0 and k8s.io/api, k8s.io/apimachinery,
and k8s.io/client-go to latest versions
[cyberark/secrets-provider-for-k8s#484](https://github.com/cyberark/secrets-provider-for-k8s/pull/484)
* **Security**
    - More replace statements for golang.org/x/crypto, gopkg.in/yaml.v2, and golang.org/x/net
[cyberark/secrets-provider-for-k8s#486](https://github.com/cyberark/secrets-provider-for-k8s/pull/486)
    - Updated replace statements in go.mod to remove vulnerable versions of golang.org/x/net
[cyberark/secrets-provider-for-k8s#484](https://github.com/cyberark/secrets-provider-for-k8s/pull/484)
[cyberark/secrets-provider-for-k8s#485](https://github.com/cyberark/secrets-provider-for-k8s/pull/485)
    - Updated replace statements in go.mod to remove vulnerable versions of golang.org/x/text
[cyberark/secrets-provider-for-k8s#484](https://github.com/cyberark/secrets-provider-for-k8s/pull/488)

### cyberark/terraform-provider-conjur

#### [v0.6.4](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.4) (2022-11-14)
* **Security**
    - Added replaces for 2 versions of golang.org/x/crypto brought in by the terraform sdk to resolve CVE-2021-43565
[cyberark/terraform-provider-conjur#111](https://github.com/cyberark/terraform-provider-conjur/pull/111)
    - Upgraded to Go 1.19 [cyberark/terraform-provider-conjur#110](https://github.com/cyberark/terraform-provider-conjur/pull/110)
    - Forced golang.org/x/net to use v0.0.0-20220923203811-8be639271d50 to resolve CVE-2022-27664
[cyberark/terraform-provider-conjur#109](https://github.com/cyberark/terraform-provider-conjur/pull/109)

### cyberark/summon

#### [v0.9.5](https://github.com/cyberark/summon/releases/tag/v0.9.5) (2022-09-28)
* **Changed**
    - Upgraded example Dockerfile to use python:3.11
[cyberark/summon#243](https://github.com/cyberark/summon/pull/243)
    - Upgrade Go to 1.19
[cyberark/summon#240](https://github.com/cyberark/summon/pull/240)
* **Security**
    - Force golang.org/x/text to use v0.3.8
[cyberark/summon#241](https://github.com/cyberark/summon/pull/241)
    - Update aruba (0.6.2 -> 2.0.0), cucumber (2.0.0 -> 7.1.0) and other necessary
dependencies in acceptance/Gemfile.lock
[cyberark/summon#239](https://github.com/cyberark/summon/pull/239)
    - Update golang.org/x/net to v0.0.0-20220923203811-8be639271d50
[cyberark/summon#240](https://github.com/cyberark/summon/pull/240)
