### PR TITLE
Upgrade Go from 1.19 to 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Upgrade Go in k8s-ci/Dockerfile to 1.20
+  [cyberark/conjur-oss-suite-release#267](https://github.com/cyberark/conjur-oss-suite-release/pull/267)
+
 ## [v1.19.3+suite.1] - 2023-04-21
 
 ## [v1.19.2+suite.1] - 2023-03-03

--- a/k8s-ci/Dockerfile
+++ b/k8s-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.20
 
 RUN mkdir -p /src
 WORKDIR /src


### PR DESCRIPTION
### Desired Outcome

This pull request upgrades Go from 1.19 to 1.20 in k8s-ci/Dockerfile.

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [X] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [X] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
