### PR TITLE
Release v1.19.5+suite.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.19.5+suite.1] - 2023-06-29
+
 ### Security
 - Upgrade Go in k8s-ci/Dockerfile to 1.20
   [cyberark/conjur-oss-suite-release#267](https://github.com/cyberark/conjur-oss-suite-release/pull/267)
@@ -106,9 +108,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   open in a new window, unless the link points to a CyberArk docs site.
   [cyberark/conjur-oss-suite-release#199](https://github.com/cyberark/conjur-oss-suite-release/issues/199)
 
-[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.3+suite.1...HEAD
-[v1.19.0+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.2+suite.1...v1.19.3+suite.1
-[v1.19.0+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.0+suite.1...v1.19.2+suite.1
+[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.5+suite.1...HEAD
+[v1.19.5+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.3+suite.1...v1.19.5+suite.1
+[v1.19.3+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.2+suite.1...v1.19.3+suite.1
+[v1.19.2+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.0+suite.1...v1.19.2+suite.1
 [v1.19.0+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.18.4+suite.1...v1.19.0+suite.1
 [v1.18.4+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.18.0+suite.1...v1.18.4+suite.1
 [v1.18.0+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.17.6+suite.1...v1.18.0+suite.1

--- a/release-testing/secretless_test.go
+++ b/release-testing/secretless_test.go
@@ -1,3 +1,4 @@
+//go:build release_test
 // +build release_test
 
 package main

--- a/suite.yml
+++ b/suite.yml
@@ -11,7 +11,7 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.19.3
+        version: v1.19.5
       - name: cyberark/conjur-openapi-spec
         url: https://github.com/cyberark/conjur-openapi-spec
         description: Conjur OpenAPI v3 specification
@@ -28,7 +28,7 @@ section:
       - name: cyberark/conjur-cli-go
         url: https://github.com/cyberark/conjur-cli-go
         description: Conjur Go CLI
-        version: v8.0.9
+        version: v8.0.10
       - name: cyberark/conjur-api-dotnet
         url: https://github.com/cyberark/conjur-api-dotnet
         description: Conjur .Net Client Library
@@ -36,11 +36,11 @@ section:
       - name: cyberark/conjur-api-go
         url: https://github.com/cyberark/conjur-api-go
         description: Conjur Golang Client Library
-        version: v0.11.0
+        version: v0.11.1
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
-        version: v3.0.4
+        version: v3.0.5
       - name: cyberark/conjur-api-python
         url: https://github.com/cyberark/conjur-api-python
         description: Conjur Python Client Library
@@ -48,7 +48,7 @@ section:
       - name: cyberark/conjur-api-ruby
         url: https://github.com/cyberark/conjur-api-ruby
         description: Conjur Ruby Client Library
-        version: v5.4.0
+        version: v5.4.1
 
   - name: Platform Integrations
     description: Tools for Conjur integrations with platforms and cloud providers.
@@ -58,25 +58,25 @@ section:
         description: The Conjur Buildpack will use the Conjur identity provided
           by the Conjur Service Broker to inject secrets into your application
           environment at runtime.
-        version: v2.2.7
+        version: v2.2.8
       - name: cyberark/conjur-service-broker
         url: https://github.com/cyberark/conjur-service-broker
         description: The Conjur Service Broker provides your applications running
           in Cloud Foundry with a Conjur identity.
-        version: v1.2.9
+        version: v1.2.10
       - name: cyberark/conjur-authn-k8s-client
         url: https://github.com/cyberark/conjur-authn-k8s-client
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        version: v0.25.0
+        version: v0.25.1
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
         tool: Kubernetes
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        version: v1.5.0
+        version: v1.5.1
 
   - name: DevOps Tools
     description: Conjur OSS integrations with DevOps tools.
@@ -108,7 +108,7 @@ section:
         tool: Terraform
         description: Terraform provider that makes secrets in Conjur available in
           Terraform manifests.
-        version: v0.6.5
+        version: v0.6.6
 
   - name: Secretless Broker
     description: Secure your apps by making them Secretless.
@@ -128,8 +128,8 @@ section:
         url: https://github.com/cyberark/summon
         description: Summon is a secure tool to inject secrets into a subprocess
           environment.
-        version: v0.9.5
+        version: v0.9.6
       - name: cyberark/summon-conjur
         url: https://github.com/cyberark/summon-conjur
         description: Summon provider for Conjur.
-        version: v0.7.0
+        version: v0.7.1


### PR DESCRIPTION
# Release Notes
All notable changes to this project will be documented in this file.

## [1.19.5+suite.1] - 2023-06-28

## Table of Contents

- [Components](#components)
- [Installation Instructions for the Suite Release Version of Conjur](#installation-instructions-for-the-suite-release-version-of-conjur)
- [Upgrade Instructions](#upgrade-instructions)
- [Changes](#changes)

## Components

These are the components that combine to create this Conjur OSS Suite release and links
to their releases:

### Conjur Server
- **[cyberark/conjur v1.19.5](https://github.com/cyberark/conjur/releases/tag/v1.19.5)** (2023-06-29) 
- **[cyberark/conjur-openapi-spec v5.3.0](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.3.0)** (2021-12-22) 
- **[cyberark/conjur-oss-helm-chart v2.0.6](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.6)** (2023-03-09) 

### Conjur SDK
- **[cyberark/conjur-cli-go v8.0.10](https://github.com/cyberark/conjur-cli-go/releases/tag/v8.0.10)** (2023-06-29) 
- **[cyberark/conjur-api-dotnet v2.1.1](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.1.1)** (2022-03-14) 
- **[cyberark/conjur-api-go v0.11.1](https://github.com/cyberark/conjur-api-go/releases/tag/v0.11.1)** () 
- **[cyberark/conjur-api-java v3.0.5](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.5)** (2023-06-08) 
- **[cyberark/conjur-api-python v0.1.0](https://github.com/cyberark/conjur-api-python/releases/tag/v0.1.0)** (2023-02-14) 
- **[cyberark/conjur-api-ruby v5.4.1](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.4.1)** (2023-06-14) 

### Platform Integrations
- **[cyberark/cloudfoundry-conjur-buildpack v2.2.8](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.8)** (2023-06-21) 
- **[cyberark/conjur-service-broker v1.2.10](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.10)** (2023-06-21) 
- **[cyberark/conjur-authn-k8s-client v0.25.1](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.25.1)** (2023-06-12) 
- **[cyberark/secrets-provider-for-k8s v1.5.1](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.5.1)** (2023-05-26) 

### DevOps Tools
- **[cyberark/ansible-conjur-collection v1.2.0](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.2.0)** (2020-09-01) 
- **[cyberark/ansible-conjur-host-identity v0.3.2](https://github.com/cyberark/ansible-conjur-host-identity/releases/tag/v0.3.2)** (2020-12-29) 
- **[cyberark/conjur-puppet v3.1.0](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.0)** (2020-10-08) 
- **[cyberark/terraform-provider-conjur v0.6.6](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.6)** (2023-06-21) 

### Secretless Broker
- **[cyberark/secretless-broker v1.7.17](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.17)** (2023-04-17) 

### Summon
- **[cyberark/summon v0.9.6](https://github.com/cyberark/summon/releases/tag/v0.9.6)** (2023-06-14) 
- **[cyberark/summon-conjur v0.7.1](https://github.com/cyberark/summon-conjur/releases/tag/v0.7.1)** (2023-06-14) 

## Installation Instructions for the Suite Release Version of Conjur

Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.

+ **Docker or docker-compose**

  Set the container image tag to `cyberark/conjur:1.19.5`.
  For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
  ```
  image: cyberark/conjur:1.19.5
  ```

+ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

  Update the `image.tag` value and use the appropriate release of the helm chart:
  ```
  helm install ... \
    --set image.tag="1.19.5" \
    ...
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v2.0.6/conjur-oss-2.0.6.tgz
  ```

## Upgrade Instructions

Upgrade instructions are available for the following components:
- [cyberark/conjur](https://github.com/cyberark/conjur/blob/master/UPGRADING.md)
- [cyberark/conjur-oss-helm-chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)

## Changes
The following are changes to the constituent components since the last Conjur
OSS Suite release:
- [cyberark/conjur](#cyberarkconjur)
- [cyberark/conjur-cli-go](#cyberarkconjur-cli-go)
- [cyberark/conjur-api-java](#cyberarkconjur-api-java)
- [cyberark/conjur-api-ruby](#cyberarkconjur-api-ruby)
- [cyberark/cloudfoundry-conjur-buildpack](#cyberarkcloudfoundry-conjur-buildpack)
- [cyberark/conjur-service-broker](#cyberarkconjur-service-broker)
- [cyberark/conjur-authn-k8s-client](#cyberarkconjur-authn-k8s-client)
- [cyberark/secrets-provider-for-k8s](#cyberarksecrets-provider-for-k8s)
- [cyberark/terraform-provider-conjur](#cyberarkterraform-provider-conjur)
- [cyberark/summon](#cyberarksummon)
- [cyberark/summon-conjur](#cyberarksummon-conjur)

### cyberark/conjur

#### [v1.19.5](https://github.com/cyberark/conjur/releases/tag/v1.19.5) (2023-06-29)
* **Changed**
    - OIDC tokens will now have a default ttl of 60 mins
[cyberark/conjur#2800](https://github.com/cyberark/conjur/pull/2800)
* **Fixed**
    - AuthnJWT now supports claims that include hyphens and inline namespaces.
[cyberark/conjur#2792](https://github.com/cyberark/conjur/pull/2792)
    - Authn-IAM now uses the host in the signed headers to determine which STS endpoint
(global or regional) to use for validation.
* **Security**
    - Update bundler to 2.2.33 to remove CVE-2021-43809
[cyberark/conjur#2804](https://github.com/cyberark/conjur/pull/2804/files)

### cyberark/conjur-cli-go

#### [v8.0.10](https://github.com/cyberark/conjur-cli-go/releases/tag/v8.0.10) (2023-06-29)
* **Fixed**
    - Fixed missing example commands in help output
[cyberark/conjur-cli-go#134](https://github.com/cyberark/conjur-cli-go/pull/134)
* **Security**
    - Upgrade golang.org/x/net to v0.10.0
[cyberark/conjur-cli-go#139](https://github.com/cyberark/conjur-cli-go/pull/139)
    - Upgrade golang.org/x/net to v0.10.0, golang.org/x/crypto to v0.9.0,
golang.org/x/sys to v0.8.0, golang.org/x/text to v0.9.0, and Go to 1.20
[cyberark/conjur-cli-go#138](https://github.com/cyberark/conjur-cli-go/pull/138)

### cyberark/conjur-api-java

#### [v3.0.5](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.5) (2023-06-08)
* **Changed**
    - Migrate JAX-RS to latest Jakarta version
[cyberark/conjur-api-java#119](https://github.com/cyberark/conjur-api-java/issues/119)
    - Avoid calling login for host
[cyberark/conjur-api-java#117](https://github.com/cyberark/conjur-api-java/pull/117)
* **Fixed**
    - Fix dependency information stripped from non-shaded jar
[cyberark/conjur-api-java#119](https://github.com/cyberark/conjur-api-java/issues/119)
* **Security**
    - Update nginx to 1.24 in Dockerfile.nginx
[cyberark/conjur-api-java#118](https://github.com/cyberark/conjur-api-java/issues/118)

### cyberark/conjur-api-ruby

#### [v5.4.1](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.4.1) (2023-06-14)
* **Added**
    - Added authenticate wrapper to access unparsed response object (including headers).
[cyberark/conjur-api-ruby#213](https://github.com/cyberark/conjur-api-ruby/pull/213)
    - Support Ruby v3.1 and v3.2.
[cyberark/conjur-api-ruby#220](https://github.com/cyberark/conjur-api-ruby/pull/220)

### cyberark/cloudfoundry-conjur-buildpack

#### [v2.2.8](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.8) (2023-06-21)
* **Security**
    - Upgrade golang.org/x/net to v0.10.0, golang.org/x/text to v0.9.0, golang.org/x/sys to v0.8.0, rack to 3.0.1,
spring-boot to 3.0.6, and java to 17
[cyberark/cloudfoundry-conjur-buildpack#172](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/172)
    - Update ruby in ci/parse-changelog.sh from 2.5 to 3.1
[cyberark/cloudfoundry-conjur-buildpack#170](https://github.com/cyberark/cloudfoundry-conjur-buildpack/pull/170)

### cyberark/conjur-service-broker

#### [v1.2.10](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.10) (2023-06-21)
* **Security**
    - Upgrade ruby to 3.2, Go image to 1.20-alpine, and golang.org/x/sys to v0.8.0
[cyberark/conjur-service-broker#331](https://github.com/cyberark/conjur-service-broker/pull/331)
    - Update nokogiri to 1.14.3 to address [https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-pxvg-2qj5-37jq](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-pxvg-2qj5-37jq)
[cyberark/conjur-service-broker#326](https://github.com/cyberark/conjur-service-broker/pull/326)

### cyberark/conjur-authn-k8s-client

#### [v0.25.1](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.25.1) (2023-06-12)
* **Security**
    - Upgrade Dockerfile base images to golang:1.20 and golang.org/x/sys dependency to 0.8.0
[cyberark/conjur-authn-k8s-client#516](https://github.com/cyberark/conjur-authn-k8s-client/pull/516)
    - Update ruby fom 2.5 to 3.1 in bin/parse-changelog.sh
[cyberark/conjur-authn-k8s-client#514](https://github.com/cyberark/conjur-authn-k8s-client/pull/514)
    - Upgrade container security settings
[cyberark/conjur-authn-k8s-client#518](https://github.com/cyberark/conjur-authn-k8s-client/pull/518)

### cyberark/secrets-provider-for-k8s

#### [v1.5.1](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.5.1) (2023-05-26)
* **Security**
    - Forced github.com/emicklei/go-restful/v3 to use v3.10.2 to remove PRISMA-2022-0227 (found in Twistlock scan)
and updated versions of gotelemetry.io/otel (to 1.16.0), github.com/stretchr/testify (to 1.8.3), and
the k8s.io libraries (to 0.27.2)
[cyberark/secrets-provider-for-k8s#526](https://github.com/cyberark/secrets-provider-for-k8s/pull/526)

### cyberark/terraform-provider-conjur

#### [v0.6.6](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.6) (2023-06-21)
* **Security**
    - Updated golang.org/x/sys to v0.8.0 and golang.org/x/text to v0.9.0
[cyberark/terraform-provider-conjur#123](https://github.com/cyberark/terraform-provider-conjur/pull/123)
    - Updated golang.org/x/net to v0.7.0 for CVE-2022-41721 and CVE-2022-41723, and
golang.org/x/text to v0.3.8 for CVE_2022-32149
[cyberark/terraform-provider-conjur#117](https://github.com/cyberark/terraform-provider-conjur/pull/117)

### cyberark/summon

#### [v0.9.6](https://github.com/cyberark/summon/releases/tag/v0.9.6) (2023-06-14)
* **Security**
    - Upgrade golang.org/x/net to v0.10.0, golang.org/x/crypto to v0.9.0,
golang.org/x/sys to v0.8.0, and Go to 1.20
[cyberark/summon#247](https://github.com/cyberark/summon/pull/247)
    - Upgrade golang.org/x/net to v0.7.0 for CVE-2022-41721 and CVE-2022-41722 (not vulnerable)
[cyberark/summon#245](https://github.com/cyberark/summon/pull/245)

### cyberark/summon-conjur

#### [v0.7.1](https://github.com/cyberark/summon-conjur/releases/tag/v0.7.1) (2023-06-14)
* **Security**
    - Update golang.org/x/sys to v0.8.0, gopkg.in/yaml.v3 to v3.0.1, and Go to 1.20
in Dockerfile.text
[cyberark/summon-conjur#112](https://github.com/cyberark/summon-conjur/pull/112)
