### PR TITLE
Suite release v1.20.0+suite.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ c.out
 .DS_Store
 bin/cc-test-reporter
 drafts/RELEASE_NOTES.md
+
+release-testing/*.txt
+release-testing/store*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v1.20.0+suite.1] - 2023-10-02
+
 ## [v1.19.5+suite.1] - 2023-06-29
 
 ### Security
@@ -108,7 +110,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   open in a new window, unless the link points to a CyberArk docs site.
   [cyberark/conjur-oss-suite-release#199](https://github.com/cyberark/conjur-oss-suite-release/issues/199)
 
-[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.5+suite.1...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.20.0+suite.1...HEAD
+[v1.20.0+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.5+suite.1...v1.20.0+suite.1
 [v1.19.5+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.3+suite.1...v1.19.5+suite.1
 [v1.19.3+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.2+suite.1...v1.19.3+suite.1
 [v1.19.2+suite.1]: https://github.com/cyberark/conjur-oss-suite-release/compare/v1.19.0+suite.1...v1.19.2+suite.1

--- a/suite.yml
+++ b/suite.yml
@@ -118,7 +118,7 @@ section:
         description: Secretless Broker can be used to securely connect your
           applications to services they need - without ever having to fetch or
           manage passwords and keys.
-        version: v1.7.18
+        version: v1.7.19
 
   - name: Summon
     description: Run your processes wrapped with Summon to ensure they have

--- a/suite.yml
+++ b/suite.yml
@@ -11,16 +11,16 @@ section:
         description: Conjur OSS server. Conjur comes built-in with custom authenticators
           for Kubernetes, OpenShift, AWS IAM, OIDC, and more.
         upgrade_url: https://github.com/cyberark/conjur/blob/master/UPGRADING.md
-        version: v1.19.5
+        version: v1.20.0
       - name: cyberark/conjur-openapi-spec
         url: https://github.com/cyberark/conjur-openapi-spec
         description: Conjur OpenAPI v3 specification
-        version: v5.3.0
+        version: v5.3.1
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying Conjur OSS.
         upgrade_url: https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment
-        version: v2.0.6
+        version: v2.0.7
 
   - name: Conjur SDK
     description: Conjur Command Line Interface (CLI) and Client Libraries
@@ -36,7 +36,7 @@ section:
       - name: cyberark/conjur-api-go
         url: https://github.com/cyberark/conjur-api-go
         description: Conjur Golang Client Library
-        version: v0.11.1
+        version: v0.11.0
       - name: cyberark/conjur-api-java
         url: https://github.com/cyberark/conjur-api-java
         description: Conjur Java Client Library
@@ -69,14 +69,14 @@ section:
         tool: Kubernetes
         description: The Conjur authenticator client can be deployed as a sidecar
           or init container to ensure your application has a valid Conjur access token.
-        version: v0.25.1
+        version: v0.26.0
       - name: cyberark/secrets-provider-for-k8s
         url: https://github.com/cyberark/secrets-provider-for-k8s
         tool: Kubernetes
         description: The Conjur Secrets Provider for K8s is deployed as an init
           container in your application pod. It injects secrets from Conjur
           into Kubernetes secrets, which are accessible to your application pod.
-        version: v1.5.1
+        version: v1.6.0
 
   - name: DevOps Tools
     description: Conjur OSS integrations with DevOps tools.
@@ -88,7 +88,7 @@ section:
           Includes an Ansible role to bootstrap Ansible hosts with a Conjur
           identity, and a lookup plugin to enable easy access to Conjur secrets
           from within your Ansible playbooks, etc.
-        version: v1.2.0
+        version: v1.2.2
       - name: cyberark/ansible-conjur-host-identity
         url: https://github.com/cyberark/ansible-conjur-host-identity
         tool: Ansible
@@ -102,7 +102,7 @@ section:
         description: Puppet module that simplifies the operation of establishing
           Conjur host identity and allows authorized Puppet nodes to fetch secrets
           from Conjur.
-        version: v3.1.0
+        version: v3.1.1
       - name: cyberark/terraform-provider-conjur
         url: https://github.com/cyberark/terraform-provider-conjur
         tool: Terraform
@@ -118,7 +118,7 @@ section:
         description: Secretless Broker can be used to securely connect your
           applications to services they need - without ever having to fetch or
           manage passwords and keys.
-        version: v1.7.17
+        version: v1.7.18
 
   - name: Summon
     description: Run your processes wrapped with Summon to ensure they have


### PR DESCRIPTION
# Release Notes
All notable changes to this project will be documented in this file.

## [v1.20.0+suite.1] - 2023-10-05

## Table of Contents

- [Components](#components)
- [Installation Instructions for the Suite Release Version of Conjur](#installation-instructions-for-the-suite-release-version-of-conjur)
- [Upgrade Instructions](#upgrade-instructions)
- [Changes](#changes)

## Components

These are the components that combine to create this Conjur OSS Suite release and links
to their releases:

### Conjur Server
- **[cyberark/conjur v1.20.0](https://github.com/cyberark/conjur/releases/tag/v1.20.0)** (2023-09-21) 
- **[cyberark/conjur-openapi-spec v5.3.1](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.3.1)** (2023-07-11) 
- **[cyberark/conjur-oss-helm-chart v2.0.7](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.7)** (2023-08-30) 

### Conjur SDK
- **[cyberark/conjur-cli-go v8.0.10](https://github.com/cyberark/conjur-cli-go/releases/tag/v8.0.10)** (2023-06-29) 
- **[cyberark/conjur-api-dotnet v2.1.1](https://github.com/cyberark/conjur-api-dotnet/releases/tag/v2.1.1)** (2022-03-14) 
- **[cyberark/conjur-api-go v0.11.0](https://github.com/cyberark/conjur-api-go/releases/tag/v0.11.0)** () 
- **[cyberark/conjur-api-java v3.0.5](https://github.com/cyberark/conjur-api-java/releases/tag/v3.0.5)** (2023-06-08) 
- **[cyberark/conjur-api-python v0.1.0](https://github.com/cyberark/conjur-api-python/releases/tag/v0.1.0)** (2023-02-14) 
- **[cyberark/conjur-api-ruby v5.4.1](https://github.com/cyberark/conjur-api-ruby/releases/tag/v5.4.1)** (2023-06-14) 

### Platform Integrations
- **[cyberark/cloudfoundry-conjur-buildpack v2.2.8](https://github.com/cyberark/cloudfoundry-conjur-buildpack/releases/tag/v2.2.8)** (2023-06-21) 
- **[cyberark/conjur-service-broker v1.2.10](https://github.com/cyberark/conjur-service-broker/releases/tag/v1.2.10)** (2023-06-21) 
- **[cyberark/conjur-authn-k8s-client v0.26.0](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.26.0)** (2023-07-18) 
- **[cyberark/secrets-provider-for-k8s v1.6.0](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.6.0)** (2023-07-19) 

### DevOps Tools
- **[cyberark/ansible-conjur-collection v1.2.2](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.2.2)** (2023-09-28) 
- **[cyberark/ansible-conjur-host-identity v0.3.2](https://github.com/cyberark/ansible-conjur-host-identity/releases/tag/v0.3.2)** (2020-12-29) 
- **[cyberark/conjur-puppet v3.1.1](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.1)** (2023-08-23) 
- **[cyberark/terraform-provider-conjur v0.6.6](https://github.com/cyberark/terraform-provider-conjur/releases/tag/v0.6.6)** (2023-06-21) 

### Secretless Broker
- **[cyberark/secretless-broker v1.7.19](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.19)** (2023-11-02) 

### Summon
- **[cyberark/summon v0.9.6](https://github.com/cyberark/summon/releases/tag/v0.9.6)** (2023-06-14) 
- **[cyberark/summon-conjur v0.7.1](https://github.com/cyberark/summon-conjur/releases/tag/v0.7.1)** (2023-06-14) 

## Installation Instructions for the Suite Release Version of Conjur

Installing the Suite Release Version of Conjur requires setting the container image tag. Below are more specific instructions depending on environment.

+ **Docker or docker-compose**

  Set the container image tag to `cyberark/conjur:1.20.0`.
  For example, make the following update to the conjur service in the [quickstart docker-compose.yml](https://github.com/cyberark/conjur-quickstart/blob/master/docker-compose.yml)
  ```
  image: cyberark/conjur:1.20.0
  ```

+ [**Conjur Open Source Helm chart**](https://github.com/cyberark/conjur-oss-helm-chart)

  Update the `image.tag` value and use the appropriate release of the helm chart:
  ```
  helm install ... \
    --set image.tag="1.20.0" \
    ...
    https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v2.0.7/conjur-oss-2.0.7.tgz
  ```

## Upgrade Instructions

Upgrade instructions are available for the following components:
- [cyberark/conjur](https://github.com/cyberark/conjur/blob/master/UPGRADING.md)
- [cyberark/conjur-oss-helm-chart](https://github.com/cyberark/conjur-oss-helm-chart/tree/master/conjur-oss#upgrading-modifying-or-migrating-a-conjur-oss-helm-deployment)

## Changes
The following are changes to the constituent components since the last Conjur
OSS Suite release:
- [cyberark/conjur](#cyberarkconjur)
- [cyberark/conjur-openapi-spec](#cyberarkconjur-openapi-spec)
- [cyberark/conjur-oss-helm-chart](#cyberarkconjur-oss-helm-chart)
- [cyberark/conjur-authn-k8s-client](#cyberarkconjur-authn-k8s-client)
- [cyberark/secrets-provider-for-k8s](#cyberarksecrets-provider-for-k8s)
- [cyberark/ansible-conjur-collection](#cyberarkansible-conjur-collection)
- [cyberark/conjur-puppet](#cyberarkconjur-puppet)
- [cyberark/secretless-broker](#cyberarksecretless-broker)

### cyberark/conjur

#### [v1.20.0](https://github.com/cyberark/conjur/releases/tag/v1.20.0) (2023-09-21)
* **Added**
    - Support an optionalca-cert variable for providing custom certs/chains to verify
OIDC providers or proxies when using the OIDC authenticator
[cyberark/conjur#2933](https://github.com/cyberark/conjur/pull/2933)
    - New flag to conjurctl server command called --no-migrate which allows for skipping
the database migration step when starting the server.
[cyberark/conjur#2895](https://github.com/cyberark/conjur/pull/2895)
    - Telemetry support
[cyberark/conjur#2854](https://github.com/cyberark/conjur/pull/2854)
    - Introduces support for Policy Factory, which enables resource creation
through a new factories API.
[cyberark/conjur#2855](https://github.com/cyberark/conjur/pull/2855/files)
    - Use base images with newer Ubuntu and UBI.
Display FIPS Mode status in the UI (requires temporary fix for OpenSSL gem).
[cyberark/conjur#2874](https://github.com/cyberark/conjur/pull/2874)
* **Changed**
    - The database thread pool max connection size is now based on the number of
web worker threads per process, rather than an arbitrary fixed number. This
mitigates the possibility of a web worker becoming starved while waiting for
a connection to become available.
[cyberark/conjur#2875](https://github.com/cyberark/conjur/pull/2875)
    - Changed base-image tagging strategy
[cyberark/conjur#2926](https://github.com/cyberark/conjur/pull/2926)
* **Fixed**
    - Allow Factories with optional variables to save without error
[cyberark/conjur#2956](https://github.com/cyberark/conjur/pull/2956)
    - OIDC authenticators support https_proxy and HTTPS_PROXY environment variables
[cyberark/conjur#2902](https://github.com/cyberark/conjur/pull/2902)
    - Support plural syntax for revoke and deny
[cyberark/conjur#2901](https://github.com/cyberark/conjur/pull/2901)
    - Support Authn-IAM regional requests when host value is missing from signed headers.
[cyberark/conjur#2827](https://github.com/cyberark/conjur/pull/2827)
* **Security**
    - Upgrade google/cloud-sdk in ci/test_suites/authenticators_k8s/dev/Dockerfile/test
to use latest version (448.0.0)
[cyberark/conjur#2972](https://github.com/cyberark/conjur/pull/2972)
    - Support plural syntax for revoke and deny
[cyberark/conjur#2901](https://github.com/cyberark/conjur/pull/2901)
    - Previously, attempting to add and remove a privilege in the same policy load
resulted in only the positive privilege (grant, permit) taking effect. Now we
fail safe and the negative privilege statement (revoke, deny) is the final
outcome
[cyberark/conjur#2907](https://github.com/cyberark/conjur/pull/2907)
    - Update puma to 6.3.1 to address CVE-2023-40175.
[cyberark/conjur#2925](https://github.com/cyberark/conjur/pull/2925)

### cyberark/conjur-openapi-spec

#### [v5.3.1](https://github.com/cyberark/conjur-openapi-spec/releases/tag/v5.3.1) (2023-07-11)
* **Removed**
    - Removed possible 403 response code from Roles API endpoints. As of Conjur
v1.19.3, requests to the Roles API return 404 when the caller has insufficient
privilege - see [cyberark/conjur#2755](https://github.com/cyberark/conjur/pull/2755).
[cyberark/conjur-openapi-spec#225](https://github.com/cyberark/conjur-openapi-spec/pull/225)

### cyberark/conjur-oss-helm-chart

#### [v2.0.7](https://github.com/cyberark/conjur-oss-helm-chart/releases/tag/v2.0.7) (2023-08-30)
* **Changed**
    - The default Postgres server version is incremented to 15.4 from 10.16.
[cyberark/conjur-oss-helm-chart#185](https://github.com/cyberark/conjur-oss-helm-chart/pull/185)

### cyberark/conjur-authn-k8s-client

#### [v0.26.0](https://github.com/cyberark/conjur-authn-k8s-client/releases/tag/v0.26.0) (2023-07-18)
* **Added**
    - Log level is now configurable using the LOG_LEVEL environment variable or conjur.org/log-level annotation.
The existing DEBUG environment variable and conjur.org/debug-logging annotation is deprecated and will be removed in a future update.
[cyberark/conjur-authn-k8s-client#522](https://github.com/cyberark/conjur-authn-k8s-client/pull/522)
* **Fixed**
    - Update RH base image to ubi9/ubi to match the libc version of the authenticator-client-builder image.
[cyberark/conjur-authn-k8s-client#520](https://github.com/cyberark/conjur-authn-k8s-client/pull/520)
* **Security**
    - Update YAML files to include extra security layers to reduce Snyk vulnerabilities
[cyberark/conjur-authn-k8s-client#523](https://github.com/cyberark/conjur-authn-k8s-client/pull/523)

### cyberark/secrets-provider-for-k8s

#### [v1.6.0](https://github.com/cyberark/secrets-provider-for-k8s/releases/tag/v1.6.0) (2023-07-19)
* **Added**
    - Log level is now configurable using the LOG_LEVEL environment variable or conjur.org/log-level annotation.
The existing DEBUG environment variable and conjur.org/debug-logging annotation is deprecated and will be removed in a future update.
[cyberark/secrets-provider-for-k8s#534](https://github.com/cyberark/secrets-provider-for-k8s/pull/534)
* **Security**
    - Upgrade google/cloud-sdk to v437.0.0-slim
[cyberark/secrets-provider-for-k8s#533](https://github.com/cyberark/secrets-provider-for-k8s/pull/533)
    - Upgrade google/cloud-sdk to v435.0.1 and google.golang.org/protobuf to v1.29.1
[cyberark/secrets-provider-for-k8s#531](https://github.com/cyberark/secrets-provider-for-k8s/pull/531)

### cyberark/ansible-conjur-collection

#### [v1.2.1](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.2.1) (2023-09-20)
* **Added**
    - Tests against Ansible versions 6, 7 and 8.
[cyberark/ansible-conjur-collection#195](https://github.com/cyberark/ansible-conjur-collection/pull/195)
* **Fixed**
    - Restore custom error messages for missing required variables.
[cyberark/ansible-conjur-collection#197](https://github.com/cyberark/ansible-conjur-collection/pull/197)
* **Security**
    - Upgrade dev/test nginx base images to 1.24.0, ubuntu base image to 22.04.
[cyberark/ansible-conjur-collection#189](https://github.com/cyberark/ansible-conjur-collection/pull/189)
    - Clean up unused Python imports.
[cyberark/ansible-conjur-collection#194](https://github.com/cyberark/ansible-conjur-collection/pull/194)
#### [v1.2.2](https://github.com/cyberark/ansible-conjur-collection/releases/tag/v1.2.2) (2023-09-28)
* **Changed**
    - Bump required Ansible version to >= 2.13
[cyberark/ansible-conjur-collection#198](https://github.com/cyberark/ansible-conjur-collection/pull/198)
    - Ignore dev folder when building the collection
[cyberark/ansible-conjur-collection#198](https://github.com/cyberark/ansible-conjur-collection/pull/198)

### cyberark/conjur-puppet

#### [v3.1.1](https://github.com/cyberark/conjur-puppet/releases/tag/v3.1.1) (2023-08-23)
* **Security**
    - Upgrade Ruby base image version to 3.3-rc-slim
[cyberark/conjur-puppet#259](https://github.com/cyberark/conjur-puppet/pull/259)
    - Upgrade PDK and Ruby base image version to 3.2.2
[cyberark/conjur-puppet#256](https://github.com/cyberark/conjur-puppet/pull/256)
    - Upgrade PDK and Ruby base image version
[cyberark/conjur-puppet#253](https://github.com/cyberark/conjur-puppet/pull/253)

### cyberark/secretless-broker

#### [v1.7.19](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.19) (2023-11-02)
* **Added**
    - Add support for caching_sha256_password to mysql connector

#### [v1.7.18](https://github.com/cyberark/secretless-broker/releases/tag/v1.7.18) (2023-08-22)
* **Added**
    - Added support for SCRAM-SHA-256 to postgres connector
* **Changed**
    - Update CRD test script.
[cyberark/secretless-broker#1499](https://github.com/cyberark/secretless-broker/pull/1499)
* **Security**
    - Updated github.com/docker/docker to v24.0.5 (CONJSE-1798)
